### PR TITLE
Implement domain layer migration (Phases 0-2)

### DIFF
--- a/src/domain/__tests__/helpers/LocationFixtures.ts
+++ b/src/domain/__tests__/helpers/LocationFixtures.ts
@@ -1,0 +1,25 @@
+import { LocationProps } from '../../locations/Location';
+import { emptyAddress } from '../../../restaurant/misc/Address';
+
+export function createTestLocationProps(overrides?: Partial<LocationProps>): LocationProps {
+  return {
+    businessId: 'biz-1',
+    name: 'Main Street',
+    isActive: true,
+    linkedObjects: {},
+    address: { ...emptyAddress },
+    isPrimary: false,
+    dailyOrderCounter: 0,
+    formattedAddress: null,
+    displayName: null,
+    imageUrls: [],
+    geoCoordinates: null,
+    utcOffset: null,
+    businessHours: null,
+    phoneNumber: null,
+    email: null,
+    currency: null,
+    isAcceptsMobileOrders: null,
+    ...overrides,
+  };
+}

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -4,4 +4,5 @@ export { TenantEntity, TenantEntityProps } from './TenantEntity';
 export { MetadataProjection, MetaLinkDeclaration, MetadataSpec } from './MetadataSpec';
 export { LinkedObjectRef, LinkedObjectMap } from './LinkedObjectRef';
 export * as ConnectedAccounts from './connected-accounts';
+export * as Locations from './locations';
 export * as Orders from './orders';

--- a/src/domain/locations/Location.ts
+++ b/src/domain/locations/Location.ts
@@ -1,0 +1,76 @@
+import { TenantEntity, TenantEntityProps } from '../TenantEntity';
+import { MetadataProjection } from '../MetadataSpec';
+import { LinkedObjectRef, LinkedObjectMap } from '../LinkedObjectRef';
+import { Address } from '../../restaurant/misc/Address';
+import { BusinessHours } from '../../utils/schedule';
+import { Coordinates } from '../../utils/geo';
+
+export interface LocationMeta {
+  name: string;
+  isActive: boolean;
+}
+
+export interface LocationProps extends TenantEntityProps {
+  name: string;
+  isActive: boolean;
+  linkedObjects: LinkedObjectMap;
+  address: Address;
+  isPrimary?: boolean;
+  dailyOrderCounter?: number;
+  formattedAddress?: string | null;
+  displayName?: string | null;
+  imageUrls?: string[];
+  geoCoordinates?: Coordinates | null;
+  utcOffset?: number | null;
+  businessHours?: BusinessHours | null;
+  phoneNumber?: string | null;
+  email?: string | null;
+  currency?: string | null;
+  isAcceptsMobileOrders?: boolean | null;
+}
+
+export class Location extends TenantEntity implements MetadataProjection<LocationMeta> {
+  name: string;
+  isActive: boolean;
+  linkedObjects: LinkedObjectMap;
+  address: Address;
+  isPrimary: boolean;
+  dailyOrderCounter: number;
+  formattedAddress: string | null;
+  displayName: string | null;
+  imageUrls: string[];
+  geoCoordinates: Coordinates | null;
+  utcOffset: number | null;
+  businessHours: BusinessHours | null;
+  phoneNumber: string | null;
+  email: string | null;
+  currency: string | null;
+  isAcceptsMobileOrders: boolean | null;
+
+  constructor(props: LocationProps) {
+    super(props);
+    this.name = props.name;
+    this.isActive = props.isActive;
+    this.linkedObjects = props.linkedObjects;
+    this.address = props.address;
+    this.isPrimary = props.isPrimary ?? false;
+    this.dailyOrderCounter = props.dailyOrderCounter ?? 0;
+    this.formattedAddress = props.formattedAddress ?? null;
+    this.displayName = props.displayName ?? null;
+    this.imageUrls = props.imageUrls ?? [];
+    this.geoCoordinates = props.geoCoordinates ?? null;
+    this.utcOffset = props.utcOffset ?? null;
+    this.businessHours = props.businessHours ?? null;
+    this.phoneNumber = props.phoneNumber ?? null;
+    this.email = props.email ?? null;
+    this.currency = props.currency ?? null;
+    this.isAcceptsMobileOrders = props.isAcceptsMobileOrders ?? null;
+  }
+
+  metadata(): LocationMeta {
+    return {
+      name: this.name,
+      isActive: this.isActive,
+    };
+  }
+}

--- a/src/domain/locations/__tests__/Location.test.ts
+++ b/src/domain/locations/__tests__/Location.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { Location } from '../Location';
+import { createTestLocationProps } from '../../__tests__/helpers/LocationFixtures';
+import { emptyAddress } from '../../../restaurant/misc/Address';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('Location (domain)', () => {
+  it('constructs with all props', () => {
+    const now = new Date('2024-01-15T10:00:00Z');
+    const address = { ...emptyAddress, addressLine1: '123 Main St', city: 'Portland' };
+    const location = new Location(createTestLocationProps({
+      Id: 'loc-1',
+      businessId: 'biz-1',
+      name: 'Downtown',
+      isActive: true,
+      linkedObjects: { square: { linkedObjectId: 'sq-loc-1' } },
+      address,
+      isPrimary: true,
+      dailyOrderCounter: 42,
+      formattedAddress: '123 Main St, Portland',
+      displayName: 'Downtown Store',
+      imageUrls: ['https://img.example.com/1.jpg'],
+      geoCoordinates: { geohash: 'abc', lat: 45.5, lng: -122.6 },
+      utcOffset: -8,
+      businessHours: { periods: [{ open: { day: 1, time: '0900' }, close: { day: 1, time: '1700' } }] },
+      phoneNumber: '555-1234',
+      email: 'downtown@example.com',
+      currency: 'USD',
+      isAcceptsMobileOrders: true,
+      created: now,
+      updated: now,
+    }));
+
+    expect(location.Id).toBe('loc-1');
+    expect(location.businessId).toBe('biz-1');
+    expect(location.name).toBe('Downtown');
+    expect(location.isActive).toBe(true);
+    expect(location.linkedObjects.square.linkedObjectId).toBe('sq-loc-1');
+    expect(location.address.addressLine1).toBe('123 Main St');
+    expect(location.isPrimary).toBe(true);
+    expect(location.dailyOrderCounter).toBe(42);
+    expect(location.formattedAddress).toBe('123 Main St, Portland');
+    expect(location.displayName).toBe('Downtown Store');
+    expect(location.imageUrls).toEqual(['https://img.example.com/1.jpg']);
+    expect(location.geoCoordinates!.lat).toBe(45.5);
+    expect(location.utcOffset).toBe(-8);
+    expect(location.businessHours!.periods).toHaveLength(1);
+    expect(location.phoneNumber).toBe('555-1234');
+    expect(location.email).toBe('downtown@example.com');
+    expect(location.currency).toBe('USD');
+    expect(location.isAcceptsMobileOrders).toBe(true);
+  });
+
+  it('auto-generates UUID when no Id', () => {
+    const location = new Location(createTestLocationProps());
+    expect(location.Id).toMatch(UUID_REGEX);
+  });
+
+  it('uses provided Id', () => {
+    const location = new Location(createTestLocationProps({ Id: 'loc-123' }));
+    expect(location.Id).toBe('loc-123');
+  });
+
+  it('has businessId from TenantEntity', () => {
+    const location = new Location(createTestLocationProps({ businessId: 'biz-99' }));
+    expect(location.businessId).toBe('biz-99');
+  });
+
+  it('defaults isPrimary to false', () => {
+    const location = new Location(createTestLocationProps());
+    expect(location.isPrimary).toBe(false);
+  });
+
+  it('defaults dailyOrderCounter to 0', () => {
+    const location = new Location(createTestLocationProps());
+    expect(location.dailyOrderCounter).toBe(0);
+  });
+
+  it('defaults nullable fields to null', () => {
+    const location = new Location(createTestLocationProps());
+    expect(location.formattedAddress).toBeNull();
+    expect(location.displayName).toBeNull();
+    expect(location.geoCoordinates).toBeNull();
+    expect(location.utcOffset).toBeNull();
+    expect(location.businessHours).toBeNull();
+    expect(location.phoneNumber).toBeNull();
+    expect(location.email).toBeNull();
+    expect(location.currency).toBeNull();
+    expect(location.isAcceptsMobileOrders).toBeNull();
+  });
+
+  it('defaults imageUrls to empty array', () => {
+    const location = new Location(createTestLocationProps());
+    expect(location.imageUrls).toEqual([]);
+  });
+
+  it('metadata() returns name and isActive', () => {
+    const location = new Location(createTestLocationProps({
+      name: 'Test Location',
+      isActive: false,
+    }));
+    expect(location.metadata()).toEqual({
+      name: 'Test Location',
+      isActive: false,
+    });
+  });
+
+  it('metadata() reflects current field values', () => {
+    const location = new Location(createTestLocationProps({ name: 'Original', isActive: true }));
+    location.name = 'Updated';
+    location.isActive = false;
+    expect(location.metadata()).toEqual({ name: 'Updated', isActive: false });
+  });
+
+  it('linkedObjects stores LinkedObjectRef', () => {
+    const location = new Location(createTestLocationProps({
+      linkedObjects: {
+        square: { linkedObjectId: 'sq-123' },
+        system: { linkedObjectId: 'sys-456' },
+      },
+    }));
+    expect(location.linkedObjects.square.linkedObjectId).toBe('sq-123');
+    expect(location.linkedObjects.system.linkedObjectId).toBe('sys-456');
+  });
+});

--- a/src/domain/locations/index.ts
+++ b/src/domain/locations/index.ts
@@ -1,0 +1,2 @@
+export { Location, LocationProps, LocationMeta } from './Location';
+export { LinkedObjectRef, LinkedObjectMap } from '../LinkedObjectRef';

--- a/src/persistence/firestore/LocationMetadataSpec.ts
+++ b/src/persistence/firestore/LocationMetadataSpec.ts
@@ -1,0 +1,19 @@
+import { MetadataSpec, MetaLinkDeclaration } from '../../domain/MetadataSpec';
+import { Location, LocationMeta } from '../../domain/locations/Location';
+import Locations from '../../restaurant/roots/Locations';
+import * as Paths from '../../firestore-core/Paths';
+
+export class LocationMetadataSpec implements MetadataSpec<Location, LocationMeta> {
+  getMetadata(entity: Location): LocationMeta {
+    return entity.metadata();
+  }
+
+  getMetaLinks(entity: Location, businessId: string): MetaLinkDeclaration[] {
+    return [
+      {
+        documentPath: Locations.docRef(businessId).path,
+        fieldPath: `${Paths.CollectionNames.locations}.${entity.Id}`,
+      },
+    ];
+  }
+}

--- a/src/persistence/firestore/LocationRepository.ts
+++ b/src/persistence/firestore/LocationRepository.ts
@@ -1,0 +1,63 @@
+import { FirestoreRepository, FirestoreRepositoryConfig } from './FirestoreRepository';
+import { Location } from '../../domain/locations/Location';
+import Locations from '../../restaurant/roots/Locations';
+import * as Paths from '../../firestore-core/Paths';
+
+export class LocationRepository extends FirestoreRepository<Location> {
+  protected config(): FirestoreRepositoryConfig<Location> {
+    return {
+      collectionRef(businessId: string) {
+        return Locations.docRef(businessId)
+          .collection(Paths.CollectionNames.locations);
+      },
+      toFirestore(location: Location): FirebaseFirestore.DocumentData {
+        return {
+          name: location.name,
+          isActive: location.isActive,
+          linkedObjects: JSON.parse(JSON.stringify(location.linkedObjects)),
+          address: JSON.parse(JSON.stringify(location.address)),
+          isPrimary: location.isPrimary,
+          dailyOrderCounter: location.dailyOrderCounter,
+          formattedAddress: location.formattedAddress,
+          displayName: location.displayName,
+          imageUrls: location.imageUrls,
+          geoCoordinates: location.geoCoordinates ? JSON.parse(JSON.stringify(location.geoCoordinates)) : null,
+          utcOffset: location.utcOffset,
+          businessHours: location.businessHours ? JSON.parse(JSON.stringify(location.businessHours)) : null,
+          phoneNumber: location.phoneNumber,
+          email: location.email,
+          currency: location.currency,
+          isAcceptsMobileOrders: location.isAcceptsMobileOrders,
+          created: location.created.toISOString(),
+          updated: location.updated.toISOString(),
+          isDeleted: location.isDeleted,
+        };
+      },
+      fromFirestore(data: FirebaseFirestore.DocumentData, id: string, businessId: string): Location {
+        return new Location({
+          Id: id,
+          businessId,
+          name: data.name,
+          isActive: data.isActive,
+          linkedObjects: data.linkedObjects ?? {},
+          address: data.address,
+          isPrimary: data.isPrimary,
+          dailyOrderCounter: data.dailyOrderCounter,
+          formattedAddress: data.formattedAddress,
+          displayName: data.displayName,
+          imageUrls: data.imageUrls,
+          geoCoordinates: data.geoCoordinates,
+          utcOffset: data.utcOffset,
+          businessHours: data.businessHours,
+          phoneNumber: data.phoneNumber,
+          email: data.email,
+          currency: data.currency,
+          isAcceptsMobileOrders: data.isAcceptsMobileOrders,
+          created: new Date(data.created),
+          updated: new Date(data.updated),
+          isDeleted: data.isDeleted,
+        });
+      },
+    };
+  }
+}

--- a/src/persistence/firestore/__tests__/LocationMetadataSpec.test.ts
+++ b/src/persistence/firestore/__tests__/LocationMetadataSpec.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Location } from '../../../domain/locations/Location';
+import { LocationMetadataSpec } from '../LocationMetadataSpec';
+import { createTestLocationProps } from '../../../domain/__tests__/helpers/LocationFixtures';
+
+// Mock Locations.docRef to avoid real Firestore
+vi.mock('../../../restaurant/roots/Locations', () => ({
+  default: {
+    docRef: (businessId: string) => ({
+      path: `businesses/${businessId}/public/locations`,
+    }),
+  },
+}));
+
+describe('LocationMetadataSpec', () => {
+  const spec = new LocationMetadataSpec();
+
+  it('getMetadata() returns name and isActive', () => {
+    const location = new Location(createTestLocationProps({
+      name: 'Downtown',
+      isActive: true,
+    }));
+
+    const meta = spec.getMetadata(location);
+    expect(meta).toEqual({ name: 'Downtown', isActive: true });
+  });
+
+  it('getMetadata() reflects inactive location', () => {
+    const location = new Location(createTestLocationProps({
+      name: 'Closed Branch',
+      isActive: false,
+    }));
+
+    const meta = spec.getMetadata(location);
+    expect(meta).toEqual({ name: 'Closed Branch', isActive: false });
+  });
+
+  it('getMetaLinks() returns correct document path and field path', () => {
+    const location = new Location(createTestLocationProps({
+      Id: 'loc-42',
+      businessId: 'biz-1',
+    }));
+
+    const links = spec.getMetaLinks(location, 'biz-1');
+    expect(links).toHaveLength(1);
+    expect(links[0].documentPath).toBe('businesses/biz-1/public/locations');
+    expect(links[0].fieldPath).toBe('locations.loc-42');
+  });
+
+  it('getMetaLinks() uses provided businessId', () => {
+    const location = new Location(createTestLocationProps({ Id: 'loc-1' }));
+
+    const links = spec.getMetaLinks(location, 'biz-other');
+    expect(links[0].documentPath).toBe('businesses/biz-other/public/locations');
+  });
+
+});

--- a/src/persistence/firestore/__tests__/LocationRepository.test.ts
+++ b/src/persistence/firestore/__tests__/LocationRepository.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Location } from '../../../domain/locations/Location';
+import { MetadataRegistry } from '../../MetadataRegistry';
+import { LocationRepository } from '../LocationRepository';
+import { LocationMetadataSpec } from '../LocationMetadataSpec';
+import { createTestLocationProps } from '../../../domain/__tests__/helpers/LocationFixtures';
+
+// Mock firebase-admin/firestore
+const mockTransaction = {
+  set: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+};
+
+const mockDocRef = {
+  get: vi.fn(),
+  update: vi.fn(),
+};
+
+const mockCollectionRef = {
+  doc: vi.fn(() => mockDocRef),
+  where: vi.fn(() => mockQuery),
+};
+
+const mockQuery = {
+  get: vi.fn(),
+};
+
+const mockDb = {
+  runTransaction: vi.fn(async (fn: (t: any) => Promise<void>) => fn(mockTransaction)),
+  doc: vi.fn(() => mockDocRef),
+};
+
+vi.mock('firebase-admin/firestore', () => ({
+  getFirestore: () => mockDb,
+  FieldValue: {
+    delete: () => '$$FIELD_DELETE$$',
+  },
+}));
+
+// Mock Locations.docRef to avoid real Firestore
+vi.mock('../../../restaurant/roots/Locations', () => ({
+  default: {
+    docRef: (_businessId: string) => ({
+      collection: (_name: string) => mockCollectionRef,
+      path: `businesses/${_businessId}/public/locations`,
+    }),
+  },
+}));
+
+function createFullSerializedLocation() {
+  const ts = '2024-01-15T10:00:00.000Z';
+  return {
+    name: 'Main Street',
+    isActive: true,
+    linkedObjects: {},
+    address: {
+      addressLine1: '123 Main St',
+      addressLine2: '',
+      city: 'Portland',
+      state: 'OR',
+      zip: '97201',
+      country: 'US',
+    },
+    isPrimary: false,
+    dailyOrderCounter: 0,
+    formattedAddress: null,
+    displayName: null,
+    imageUrls: [],
+    geoCoordinates: null,
+    utcOffset: null,
+    businessHours: null,
+    phoneNumber: null,
+    email: null,
+    currency: null,
+    isAcceptsMobileOrders: null,
+    created: ts,
+    updated: ts,
+    isDeleted: false,
+  };
+}
+
+describe('LocationRepository', () => {
+  let registry: MetadataRegistry;
+  let repo: LocationRepository;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registry = new MetadataRegistry();
+    repo = new LocationRepository(registry);
+  });
+
+  it('get() returns Location when doc exists', async () => {
+    const serialized = createFullSerializedLocation();
+    mockDocRef.get.mockResolvedValue({
+      exists: true,
+      data: () => serialized,
+      id: 'loc-1',
+    });
+
+    const result = await repo.get('biz-1', 'loc-1');
+    expect(result).not.toBeNull();
+    expect(result!.Id).toBe('loc-1');
+    expect(result!.businessId).toBe('biz-1');
+    expect(result!.name).toBe('Main Street');
+    expect(result!.isActive).toBe(true);
+    expect(result!.address.city).toBe('Portland');
+  });
+
+  it('get() returns null when doc missing', async () => {
+    mockDocRef.get.mockResolvedValue({ exists: false });
+    const result = await repo.get('biz-1', 'missing');
+    expect(result).toBeNull();
+  });
+
+  it('set() serializes all fields correctly', async () => {
+    const ts = new Date('2024-01-15T10:00:00Z');
+    const location = new Location(createTestLocationProps({
+      Id: 'loc-1',
+      name: 'Downtown',
+      isActive: true,
+      isPrimary: true,
+      dailyOrderCounter: 42,
+      formattedAddress: '123 Main St, Portland',
+      displayName: 'Downtown Store',
+      phoneNumber: '555-1234',
+      email: 'test@example.com',
+      currency: 'USD',
+      isAcceptsMobileOrders: true,
+      created: ts,
+      updated: ts,
+    }));
+
+    await repo.set(location, 'biz-1');
+
+    expect(mockTransaction.set).toHaveBeenCalledTimes(1);
+    const data = mockTransaction.set.mock.calls[0][1];
+    expect(data.name).toBe('Downtown');
+    expect(data.isActive).toBe(true);
+    expect(data.isPrimary).toBe(true);
+    expect(data.dailyOrderCounter).toBe(42);
+    expect(data.formattedAddress).toBe('123 Main St, Portland');
+    expect(data.displayName).toBe('Downtown Store');
+    expect(data.phoneNumber).toBe('555-1234');
+    expect(data.email).toBe('test@example.com');
+    expect(data.currency).toBe('USD');
+    expect(data.isAcceptsMobileOrders).toBe(true);
+    expect(data.created).toBe('2024-01-15T10:00:00.000Z');
+    expect(data.updated).toBe('2024-01-15T10:00:00.000Z');
+    expect(data.isDeleted).toBe(false);
+  });
+
+  it('set() deep-clones nested objects', async () => {
+    const location = new Location(createTestLocationProps({
+      linkedObjects: { square: { linkedObjectId: 'sq-1' } },
+      address: { addressLine1: '123 Main', addressLine2: '', city: 'Portland', state: 'OR', zip: '97201', country: 'US' },
+      geoCoordinates: { geohash: 'abc', lat: 45.5, lng: -122.6 },
+      businessHours: { periods: [{ open: { day: 1, time: '0900' }, close: { day: 1, time: '1700' } }] },
+    }));
+
+    await repo.set(location, 'biz-1');
+
+    const data = mockTransaction.set.mock.calls[0][1];
+    expect(data.linkedObjects).not.toBe(location.linkedObjects);
+    expect(data.address).not.toBe(location.address);
+    expect(data.geoCoordinates).not.toBe(location.geoCoordinates);
+    expect(data.businessHours).not.toBe(location.businessHours);
+    // But values should match
+    expect(data.linkedObjects.square.linkedObjectId).toBe('sq-1');
+    expect(data.address.city).toBe('Portland');
+    expect(data.geoCoordinates.lat).toBe(45.5);
+  });
+
+  it('set() handles null geoCoordinates and businessHours', async () => {
+    const location = new Location(createTestLocationProps());
+    await repo.set(location, 'biz-1');
+
+    const data = mockTransaction.set.mock.calls[0][1];
+    expect(data.geoCoordinates).toBeNull();
+    expect(data.businessHours).toBeNull();
+  });
+
+  it('set() runs transaction with metadata when spec registered', async () => {
+    const spec = new LocationMetadataSpec();
+    registry.register(Location, spec);
+
+    const location = new Location(createTestLocationProps({
+      Id: 'loc-1',
+      name: 'Test',
+      isActive: true,
+    }));
+
+    await repo.set(location, 'biz-1');
+
+    expect(mockDb.runTransaction).toHaveBeenCalledTimes(1);
+    expect(mockTransaction.set).toHaveBeenCalledTimes(1);
+    // Metadata should be written to the meta link
+    expect(mockTransaction.update).toHaveBeenCalledTimes(1);
+    const updateArgs = mockTransaction.update.mock.calls[0];
+    expect(updateArgs[1]).toEqual({
+      'locations.loc-1': { name: 'Test', isActive: true },
+    });
+  });
+
+  it('set() runs transaction without metadata when no spec', async () => {
+    const location = new Location(createTestLocationProps());
+    await repo.set(location, 'biz-1');
+
+    expect(mockDb.runTransaction).toHaveBeenCalledTimes(1);
+    expect(mockTransaction.set).toHaveBeenCalledTimes(1);
+    expect(mockTransaction.update).not.toHaveBeenCalled();
+  });
+
+  it('round-trip: toFirestore -> fromFirestore preserves data', async () => {
+    const ts = new Date('2024-06-01T12:00:00Z');
+    const original = new Location(createTestLocationProps({
+      Id: 'loc-rt',
+      name: 'Round Trip',
+      isActive: false,
+      isPrimary: true,
+      dailyOrderCounter: 99,
+      formattedAddress: '456 Oak Ave',
+      displayName: 'RT Store',
+      imageUrls: ['img1.jpg', 'img2.jpg'],
+      geoCoordinates: { geohash: 'xyz', lat: 40.7, lng: -74.0 },
+      utcOffset: -5,
+      businessHours: { periods: [{ open: { day: 0, time: '0800' }, close: { day: 0, time: '2200' } }] },
+      phoneNumber: '555-9999',
+      email: 'rt@example.com',
+      currency: 'CAD',
+      isAcceptsMobileOrders: false,
+      created: ts,
+      updated: ts,
+    }));
+
+    // Capture toFirestore output via set
+    await repo.set(original, 'biz-1');
+    const serialized = mockTransaction.set.mock.calls[0][1];
+
+    // Feed it back through get (fromFirestore)
+    mockDocRef.get.mockResolvedValue({
+      exists: true,
+      data: () => serialized,
+      id: 'loc-rt',
+    });
+    const restored = await repo.get('biz-1', 'loc-rt');
+
+    expect(restored!.Id).toBe(original.Id);
+    expect(restored!.businessId).toBe('biz-1');
+    expect(restored!.name).toBe(original.name);
+    expect(restored!.isActive).toBe(original.isActive);
+    expect(restored!.isPrimary).toBe(original.isPrimary);
+    expect(restored!.dailyOrderCounter).toBe(original.dailyOrderCounter);
+    expect(restored!.formattedAddress).toBe(original.formattedAddress);
+    expect(restored!.displayName).toBe(original.displayName);
+    expect(restored!.imageUrls).toEqual(original.imageUrls);
+    expect(restored!.geoCoordinates).toEqual(original.geoCoordinates);
+    expect(restored!.utcOffset).toBe(original.utcOffset);
+    expect(restored!.businessHours).toEqual(original.businessHours);
+    expect(restored!.phoneNumber).toBe(original.phoneNumber);
+    expect(restored!.email).toBe(original.email);
+    expect(restored!.currency).toBe(original.currency);
+    expect(restored!.isAcceptsMobileOrders).toBe(original.isAcceptsMobileOrders);
+    expect(restored!.created.getTime()).toBe(original.created.getTime());
+    expect(restored!.updated.getTime()).toBe(original.updated.getTime());
+  });
+
+  it('fromFirestore handles missing optional fields', async () => {
+    mockDocRef.get.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        name: 'Minimal',
+        isActive: true,
+        address: { addressLine1: '', addressLine2: '', city: '', state: '', zip: '', country: '' },
+        created: '2024-01-01T00:00:00.000Z',
+        updated: '2024-01-01T00:00:00.000Z',
+        isDeleted: false,
+      }),
+      id: 'loc-minimal',
+    });
+
+    const result = await repo.get('biz-1', 'loc-minimal');
+    expect(result!.linkedObjects).toEqual({});
+    expect(result!.isPrimary).toBe(false);
+    expect(result!.dailyOrderCounter).toBe(0);
+    expect(result!.formattedAddress).toBeNull();
+    expect(result!.displayName).toBeNull();
+    expect(result!.imageUrls).toEqual([]);
+    expect(result!.geoCoordinates).toBeNull();
+    expect(result!.utcOffset).toBeNull();
+    expect(result!.businessHours).toBeNull();
+    expect(result!.phoneNumber).toBeNull();
+    expect(result!.email).toBeNull();
+    expect(result!.currency).toBeNull();
+    expect(result!.isAcceptsMobileOrders).toBeNull();
+  });
+
+  it('findByLinkedObject() queries correct field path', async () => {
+    mockQuery.get.mockResolvedValue({
+      docs: [{
+        data: () => createFullSerializedLocation(),
+        id: 'loc-linked',
+      }],
+    });
+
+    const result = await repo.findByLinkedObject('biz-1', 'sq-loc-1', 'square');
+
+    expect(mockCollectionRef.where).toHaveBeenCalledWith(
+      'linkedObjects.square.linkedObjectId',
+      '==',
+      'sq-loc-1',
+    );
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe('Main Street');
+  });
+});

--- a/src/persistence/firestore/index.ts
+++ b/src/persistence/firestore/index.ts
@@ -1,4 +1,6 @@
 export { FirestoreRepository, FirestoreRepositoryConfig } from './FirestoreRepository';
 export { EventRepository } from './EventRepository';
+export { LocationRepository } from './LocationRepository';
+export { LocationMetadataSpec } from './LocationMetadataSpec';
 export { OrderRepository } from './OrderRepository';
 export { linkedObjectQuery, findByLinkedObjectId } from './LinkedObjectQueries';

--- a/src/restaurant/locations/Location.ts
+++ b/src/restaurant/locations/Location.ts
@@ -28,14 +28,17 @@ export interface LocationProps {
 
 const ref = (businessId: string) => Locations.docRef(businessId).collection(Paths.CollectionNames.locations)
 
+/** @deprecated Use `Domain.Locations.Location` from `src/domain/locations/Location.ts` instead. */
 export class Location extends FirestoreObjectV2 implements LocationProps {
   // TODO try to remove this line
   static firestoreConverter = super.firestoreConverter
 
+  /** @deprecated Use `LocationRepository` instead. */
   static collectionRef (businessId: string): FirebaseFirestore.CollectionReference {
     return ref(businessId)
   }
 
+  /** @deprecated Use `LocationRepository.get()` instead. */
   static get(businessId: string, Id: string) {
     return super.getGeneric(businessId,
                             ref(businessId)
@@ -45,6 +48,7 @@ export class Location extends FirestoreObjectV2 implements LocationProps {
     )
   }
 
+  /** @deprecated Use `LocationRepository.delete()` instead. */
   static delete(businessId: string, Id: string) {
     return super.deleteGeneric(
       ref(businessId).doc(Id),
@@ -52,6 +56,7 @@ export class Location extends FirestoreObjectV2 implements LocationProps {
     )
   }
 
+  /** @deprecated Use `LocationRepository.findByLinkedObject()` instead. */
   static find(businessId: string, linkedObjectId: string, provider: Provider) {
     return FirestoreObjectV2.findGeneric(
       linkedObjectId,
@@ -62,6 +67,7 @@ export class Location extends FirestoreObjectV2 implements LocationProps {
     )
   }
 
+  /** @deprecated Use `LocationRepository.set()` instead. */
   set() {
     return super.setGeneric(
       ref(this.businessId)
@@ -72,6 +78,7 @@ export class Location extends FirestoreObjectV2 implements LocationProps {
     )
   }
 
+  /** @deprecated Use `LocationRepository.update()` instead. */
   update() {
     // TODO Update metalinks
     return super.updateGeneric(


### PR DESCRIPTION
## Summary

- **Phase 0**: Domain base classes (`DomainEntity`, `TenantEntity`, `MetadataSpec`, `LinkedObjectRef`), persistence interfaces (`Repository`, `MetadataRegistry`), Firestore repository foundation, and Vitest test framework
- **Phase 1**: Domain models for `Order` (with symbols) and `Event`, plus `OrderRepository` and `EventRepository` with full test coverage
- **Phase 2**: Migrate `LinkedObject` to domain-layer `LinkedObjectRef` type with `linkedObjectQuery`/`findByLinkedObjectId` persistence queries; add `Location` domain model, `LocationRepository`, `LocationMetadataSpec`, and deprecation notices on the legacy `Location` class

## Test plan

- [ ] Run `npx vitest` to verify all domain and persistence unit tests pass
- [ ] Run `npm run tsc` to verify TypeScript compilation succeeds
- [ ] Verify deprecated legacy `Location` methods show JSDoc deprecation warnings in IDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)