### PR TITLE
Export DistributedCounter from main barrel export

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Tests use Vitest with `globals: true`. Test files live in `__tests__/` directories alongside source code, matching `src/**/__tests__/**/*.test.ts`.
 
+## Publishing
+
+When creating a PR against `master` or `dev`, always bump the version in `package.json` before pushing. Artifact Registry rejects duplicate versions — every merge that triggers Cloud Build must have a unique version. Use semver patch bumps for fixes, minor for features.
+
 ## Verification
 
 After adding or changing dependencies in `package.json`, always run `rm -rf node_modules && npm install` before compiling to ensure a clean dependency tree. Stale `node_modules` can mask missing or incorrect dependency configurations.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -86,13 +86,26 @@ metadataRegistry.register(Location, new LocationMetadataSpec());
 metadataRegistry.register(Menu, new MenuMetadataSpec());
 metadataRegistry.register(MenuGroup, new MenuGroupMetadataSpec());
 
-// 2. Create repository instances — pass the registry to each
-const productRepo = new Persistence.ProductRepository(metadataRegistry);
-const categoryRepo = new Persistence.CategoryRepository(metadataRegistry);
+// 2. Create and populate the relationship handler registry (see section 7 for details)
+const { RelationshipHandlerRegistry, ProductRelationshipHandler,
+  OptionSetRelationshipHandler, OptionRelationshipHandler } = Persistence;
+const { Product, OptionSet, Option } = Domain.Catalog;
+const relationshipRegistry = new RelationshipHandlerRegistry();
+relationshipRegistry.register(Product, new ProductRelationshipHandler());
+relationshipRegistry.register(OptionSet, new OptionSetRelationshipHandler());
+relationshipRegistry.register(Option, new OptionRelationshipHandler());
+
+// 3. Create repository instances — pass the metadata registry to each
 const orderRepo = new Persistence.OrderRepository(metadataRegistry);
 const businessRepo = new Persistence.BusinessRepository(metadataRegistry);
 const menuRepo = new Persistence.MenuRepository(metadataRegistry);
 // ... etc. for any repositories your code needs
+
+// 4. Catalog repos that cascade metadata need a RelationshipHandlerRegistry too (see section 7)
+const productRepo = new Persistence.ProductRepository(metadataRegistry, relationshipRegistry);
+const categoryRepo = new Persistence.CategoryRepository(metadataRegistry);
+const optionSetRepo = new Persistence.OptionSetRepository(metadataRegistry, relationshipRegistry);
+const optionRepo = new Persistence.OptionRepository(metadataRegistry, relationshipRegistry);
 ```
 
 ### Complete repository list

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * as Persistence from './persistence';
 // Infrastructure — Firestore path constants & enums
 export * as Paths from './firestore-core/Paths';
 export * as Constants from './firestore-core/Constants';
+export { default as DistributedCounter } from './firestore-core/core/DistributedCounter';
 
 // Auth & User — unchanged
 export * as Authentication from './user/Authentication';


### PR DESCRIPTION
## Summary
- Re-exports `DistributedCounter` from `src/index.ts` so consumers can import it via `@kiosinc/restaurant-core-claude`

Fixes #13

## Test plan
- [x] `npm run tsc` compiles successfully
- [x] All 510 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)