### PR TITLE
Allow empty name and -1 selection sentinel (#26)

### DIFF
--- a/src/domain/__tests__/validation.test.ts
+++ b/src/domain/__tests__/validation.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
   ValidationError,
+  requireString,
   requireNonEmptyString,
   requireNonNegativeNumber,
   requireNonNegativeInteger,
+  requireNonNegativeIntegerOrNeg1,
   requireMinLessOrEqual,
 } from '../validation';
 
@@ -15,6 +17,28 @@ describe('ValidationError', () => {
     expect(err.field).toBe('name');
     expect(err.message).toContain('name');
     expect(err.message).toContain('non-empty string');
+  });
+});
+
+describe('requireString', () => {
+  it('passes for non-empty string', () => {
+    expect(() => requireString('name', 'Burger')).not.toThrow();
+  });
+
+  it('passes for empty string', () => {
+    expect(() => requireString('name', '')).not.toThrow();
+  });
+
+  it('throws for undefined', () => {
+    expect(() => requireString('name', undefined)).toThrow(ValidationError);
+  });
+
+  it('throws for null', () => {
+    expect(() => requireString('name', null)).toThrow(ValidationError);
+  });
+
+  it('throws for number', () => {
+    expect(() => requireString('name', 123)).toThrow(ValidationError);
   });
 });
 
@@ -96,6 +120,40 @@ describe('requireNonNegativeInteger', () => {
   });
 });
 
+describe('requireNonNegativeIntegerOrNeg1', () => {
+  it('passes for zero', () => {
+    expect(() => requireNonNegativeIntegerOrNeg1('sel', 0)).not.toThrow();
+  });
+
+  it('passes for positive integer', () => {
+    expect(() => requireNonNegativeIntegerOrNeg1('sel', 5)).not.toThrow();
+  });
+
+  it('passes for -1 sentinel', () => {
+    expect(() => requireNonNegativeIntegerOrNeg1('sel', -1)).not.toThrow();
+  });
+
+  it('throws for -2', () => {
+    expect(() => requireNonNegativeIntegerOrNeg1('sel', -2)).toThrow(ValidationError);
+  });
+
+  it('throws for float', () => {
+    expect(() => requireNonNegativeIntegerOrNeg1('sel', 1.5)).toThrow(ValidationError);
+  });
+
+  it('throws for NaN', () => {
+    expect(() => requireNonNegativeIntegerOrNeg1('sel', NaN)).toThrow(ValidationError);
+  });
+
+  it('throws for string', () => {
+    expect(() => requireNonNegativeIntegerOrNeg1('sel', '5')).toThrow(ValidationError);
+  });
+
+  it('throws for undefined', () => {
+    expect(() => requireNonNegativeIntegerOrNeg1('sel', undefined)).toThrow(ValidationError);
+  });
+});
+
 describe('requireMinLessOrEqual', () => {
   it('passes when min < max', () => {
     expect(() => requireMinLessOrEqual('min', 0, 'max', 10)).not.toThrow();
@@ -112,5 +170,17 @@ describe('requireMinLessOrEqual', () => {
   it('error message contains both field names and values', () => {
     expect(() => requireMinLessOrEqual('minPrice', 10, 'maxPrice', 5))
       .toThrow(/minPrice.*maxPrice/);
+  });
+
+  it('passes when min is -1 sentinel (no constraint)', () => {
+    expect(() => requireMinLessOrEqual('min', -1, 'max', 5)).not.toThrow();
+  });
+
+  it('passes when max is -1 sentinel (unlimited)', () => {
+    expect(() => requireMinLessOrEqual('min', 5, 'max', -1)).not.toThrow();
+  });
+
+  it('passes when both are -1 sentinel', () => {
+    expect(() => requireMinLessOrEqual('min', -1, 'max', -1)).not.toThrow();
   });
 });

--- a/src/domain/catalog/Category.ts
+++ b/src/domain/catalog/Category.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, baseEntityDefaults } from '../BaseEntity';
-import { requireNonEmptyString } from '../validation';
+import { requireString } from '../validation';
 import { LinkedObjectMap } from '../LinkedObjectRef';
 import { ProductMeta } from './Product';
 
@@ -26,7 +26,7 @@ export interface Category extends BaseEntity {
 }
 
 export function createCategory(input: CategoryInput & Partial<BaseEntity>): Category {
-  requireNonEmptyString('name', input.name);
+  requireString('name', input.name);
   return {
     ...baseEntityDefaults(input),
     name: input.name,

--- a/src/domain/catalog/Discount.ts
+++ b/src/domain/catalog/Discount.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, baseEntityDefaults } from '../BaseEntity';
-import { requireNonEmptyString, requireNonNegativeNumber } from '../validation';
+import { requireString, requireNonNegativeNumber } from '../validation';
 import { LinkedObjectMap } from '../LinkedObjectRef';
 
 export enum DiscountType {
@@ -29,7 +29,7 @@ export interface DiscountInput {
 }
 
 export function createDiscount(input: DiscountInput & Partial<BaseEntity>): Discount {
-  requireNonEmptyString('name', input.name);
+  requireString('name', input.name);
   requireNonNegativeNumber('value', input.value);
   return {
     ...baseEntityDefaults(input),

--- a/src/domain/catalog/Option.ts
+++ b/src/domain/catalog/Option.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, baseEntityDefaults } from '../BaseEntity';
-import { requireNonEmptyString, requireNonNegativeNumber } from '../validation';
+import { requireString, requireNonNegativeNumber } from '../validation';
 import { LinkedObjectMap } from '../LinkedObjectRef';
 import { LocationInventoryMap } from './InventoryCount';
 
@@ -35,7 +35,7 @@ export interface Option extends BaseEntity {
 }
 
 export function createOption(input: OptionInput & Partial<BaseEntity>): Option {
-  requireNonEmptyString('name', input.name);
+  requireString('name', input.name);
   requireNonNegativeNumber('price', input.price);
   return {
     ...baseEntityDefaults(input),

--- a/src/domain/catalog/OptionSet.ts
+++ b/src/domain/catalog/OptionSet.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, baseEntityDefaults } from '../BaseEntity';
-import { requireNonEmptyString, requireNonNegativeInteger, requireMinLessOrEqual } from '../validation';
+import { requireString, requireNonNegativeInteger, requireNonNegativeIntegerOrNeg1, requireMinLessOrEqual } from '../validation';
 import { LinkedObjectMap } from '../LinkedObjectRef';
 import { OptionMeta } from './Option';
 import { LocationInventoryMap } from './InventoryCount';
@@ -50,9 +50,9 @@ export interface OptionSet extends BaseEntity {
 }
 
 export function createOptionSet(input: OptionSetInput & Partial<BaseEntity>): OptionSet {
-  requireNonEmptyString('name', input.name);
-  requireNonNegativeInteger('minSelection', input.minSelection);
-  requireNonNegativeInteger('maxSelection', input.maxSelection);
+  requireString('name', input.name);
+  requireNonNegativeIntegerOrNeg1('minSelection', input.minSelection);
+  requireNonNegativeIntegerOrNeg1('maxSelection', input.maxSelection);
   requireMinLessOrEqual('minSelection', input.minSelection, 'maxSelection', input.maxSelection);
   requireNonNegativeInteger('displayOrder', input.displayOrder);
   requireNonNegativeInteger('displayTier', input.displayTier);

--- a/src/domain/catalog/Product.ts
+++ b/src/domain/catalog/Product.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, baseEntityDefaults } from '../BaseEntity';
-import { requireNonEmptyString, requireNonNegativeNumber, requireNonNegativeInteger, requireMinLessOrEqual } from '../validation';
+import { requireString, requireNonNegativeNumber, requireNonNegativeInteger, requireMinLessOrEqual } from '../validation';
 import { LinkedObjectMap } from '../LinkedObjectRef';
 import { ProductOptionSetSetting, OptionSetMeta } from './OptionSet';
 import { LocationInventoryMap } from './InventoryCount';
@@ -47,7 +47,7 @@ export interface Product extends BaseEntity {
 }
 
 export function createProduct(input: ProductInput & Partial<BaseEntity>): Product {
-  requireNonEmptyString('name', input.name);
+  requireString('name', input.name);
   requireNonNegativeNumber('minPrice', input.minPrice);
   requireNonNegativeNumber('maxPrice', input.maxPrice);
   requireMinLessOrEqual('minPrice', input.minPrice, 'maxPrice', input.maxPrice);

--- a/src/domain/catalog/ServiceCharge.ts
+++ b/src/domain/catalog/ServiceCharge.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, baseEntityDefaults } from '../BaseEntity';
-import { requireNonEmptyString, requireNonNegativeNumber } from '../validation';
+import { requireString, requireNonNegativeNumber } from '../validation';
 import { LinkedObjectMap } from '../LinkedObjectRef';
 
 export enum ServiceChargeType {
@@ -26,7 +26,7 @@ export interface ServiceChargeInput {
 }
 
 export function createServiceCharge(input: ServiceChargeInput & Partial<BaseEntity>): ServiceCharge {
-  requireNonEmptyString('name', input.name);
+  requireString('name', input.name);
   requireNonNegativeNumber('value', input.value);
   return {
     ...baseEntityDefaults(input),

--- a/src/domain/catalog/TaxRate.ts
+++ b/src/domain/catalog/TaxRate.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, baseEntityDefaults } from '../BaseEntity';
-import { requireNonEmptyString, requireNonNegativeNumber } from '../validation';
+import { requireString, requireNonNegativeNumber } from '../validation';
 import { LinkedObjectMap } from '../LinkedObjectRef';
 
 export interface TaxRate extends BaseEntity {
@@ -19,7 +19,7 @@ export interface TaxRateInput {
 }
 
 export function createTaxRate(input: TaxRateInput & Partial<BaseEntity>): TaxRate {
-  requireNonEmptyString('name', input.name);
+  requireString('name', input.name);
   requireNonNegativeNumber('rate', input.rate);
   return {
     ...baseEntityDefaults(input),

--- a/src/domain/catalog/__tests__/Category.test.ts
+++ b/src/domain/catalog/__tests__/Category.test.ts
@@ -65,8 +65,9 @@ describe('Category (domain)', () => {
   });
 
   describe('validation', () => {
-    it('throws for empty name', () => {
-      expect(() => createCategory(createTestCategoryInput({ name: '' }))).toThrow(ValidationError);
+    it('allows empty name', () => {
+      const category = createCategory(createTestCategoryInput({ name: '' }));
+      expect(category.name).toBe('');
     });
   });
 

--- a/src/domain/catalog/__tests__/Discount.test.ts
+++ b/src/domain/catalog/__tests__/Discount.test.ts
@@ -52,8 +52,9 @@ describe('Discount (domain)', () => {
   });
 
   describe('validation', () => {
-    it('throws for empty name', () => {
-      expect(() => createDiscount(createTestDiscountInput({ name: '' }))).toThrow(ValidationError);
+    it('allows empty name', () => {
+      const discount = createDiscount(createTestDiscountInput({ name: '' }));
+      expect(discount.name).toBe('');
     });
 
     it('throws for negative value', () => {

--- a/src/domain/catalog/__tests__/Option.test.ts
+++ b/src/domain/catalog/__tests__/Option.test.ts
@@ -93,8 +93,9 @@ describe('Option (domain)', () => {
   });
 
   describe('validation', () => {
-    it('throws for empty name', () => {
-      expect(() => createOption(createTestOptionInput({ name: '' }))).toThrow(ValidationError);
+    it('allows empty name', () => {
+      const option = createOption(createTestOptionInput({ name: '' }));
+      expect(option.name).toBe('');
     });
 
     it('throws for negative price', () => {

--- a/src/domain/catalog/__tests__/OptionSet.test.ts
+++ b/src/domain/catalog/__tests__/OptionSet.test.ts
@@ -95,16 +95,25 @@ describe('OptionSet (domain)', () => {
   });
 
   describe('validation', () => {
-    it('throws for empty name', () => {
-      expect(() => createOptionSet(createTestOptionSetInput({ name: '' }))).toThrow(ValidationError);
+    it('allows empty name', () => {
+      const os = createOptionSet(createTestOptionSetInput({ name: '' }));
+      expect(os.name).toBe('');
     });
 
-    it('throws for negative minSelection', () => {
-      expect(() => createOptionSet(createTestOptionSetInput({ minSelection: -1 }))).toThrow(ValidationError);
+    it('allows -1 sentinel for minSelection', () => {
+      expect(() => createOptionSet(createTestOptionSetInput({ minSelection: -1, maxSelection: -1 }))).not.toThrow();
     });
 
-    it('throws for negative maxSelection', () => {
-      expect(() => createOptionSet(createTestOptionSetInput({ maxSelection: -1, minSelection: -2 }))).toThrow(ValidationError);
+    it('throws for minSelection < -1', () => {
+      expect(() => createOptionSet(createTestOptionSetInput({ minSelection: -2 }))).toThrow(ValidationError);
+    });
+
+    it('allows -1 sentinel for maxSelection', () => {
+      expect(() => createOptionSet(createTestOptionSetInput({ maxSelection: -1 }))).not.toThrow();
+    });
+
+    it('throws for maxSelection < -1', () => {
+      expect(() => createOptionSet(createTestOptionSetInput({ maxSelection: -2 }))).toThrow(ValidationError);
     });
 
     it('throws when minSelection > maxSelection', () => {

--- a/src/domain/catalog/__tests__/Product.test.ts
+++ b/src/domain/catalog/__tests__/Product.test.ts
@@ -122,8 +122,9 @@ describe('Product (domain)', () => {
   });
 
   describe('validation', () => {
-    it('throws for empty name', () => {
-      expect(() => createProduct(createTestProductInput({ name: '' }))).toThrow(ValidationError);
+    it('allows empty name', () => {
+      const product = createProduct(createTestProductInput({ name: '' }));
+      expect(product.name).toBe('');
     });
 
     it('throws for negative minPrice', () => {

--- a/src/domain/catalog/__tests__/ServiceCharge.test.ts
+++ b/src/domain/catalog/__tests__/ServiceCharge.test.ts
@@ -39,8 +39,9 @@ describe('ServiceCharge (domain)', () => {
   });
 
   describe('validation', () => {
-    it('throws for empty name', () => {
-      expect(() => createServiceCharge(createTestServiceChargeInput({ name: '' }))).toThrow(ValidationError);
+    it('allows empty name', () => {
+      const sc = createServiceCharge(createTestServiceChargeInput({ name: '' }));
+      expect(sc.name).toBe('');
     });
 
     it('throws for negative value', () => {

--- a/src/domain/catalog/__tests__/TaxRate.test.ts
+++ b/src/domain/catalog/__tests__/TaxRate.test.ts
@@ -37,8 +37,9 @@ describe('TaxRate (domain)', () => {
   });
 
   describe('validation', () => {
-    it('throws for empty name', () => {
-      expect(() => createTaxRate({ ...createTestTaxRateInput(), name: '' })).toThrow(ValidationError);
+    it('allows empty name', () => {
+      const taxRate = createTaxRate({ ...createTestTaxRateInput(), name: '' });
+      expect(taxRate.name).toBe('');
     });
 
     it('throws for negative rate', () => {

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,5 +1,5 @@
 export { BaseEntity, generateId, baseEntityDefaults } from './BaseEntity';
-export { ValidationError, requireNonEmptyString, requireNonNegativeNumber, requireNonNegativeInteger, requireMinLessOrEqual } from './validation';
+export { ValidationError, requireString, requireNonEmptyString, requireNonNegativeNumber, requireNonNegativeInteger, requireNonNegativeIntegerOrNeg1, requireMinLessOrEqual } from './validation';
 export { MetaLinkDeclaration, MetadataSpec, createMetadataSpec } from './MetadataSpec';
 export { LinkedObjectRef, LinkedObjectMap } from './LinkedObjectRef';
 export * as Catalog from './catalog';

--- a/src/domain/locations/Location.ts
+++ b/src/domain/locations/Location.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, baseEntityDefaults } from '../BaseEntity';
-import { requireNonEmptyString } from '../validation';
+import { requireString, requireNonEmptyString } from '../validation';
 import { LinkedObjectMap } from '../LinkedObjectRef';
 import { Address } from '../misc/Address';
 import { BusinessHours } from '../../utils/schedule';
@@ -52,7 +52,7 @@ export interface Location extends BaseEntity {
 
 export function createLocation(input: LocationInput & Partial<BaseEntity>): Location {
   requireNonEmptyString('businessId', input.businessId);
-  requireNonEmptyString('name', input.name);
+  requireString('name', input.name);
   return {
     ...baseEntityDefaults(input),
     businessId: input.businessId,

--- a/src/domain/locations/__tests__/Location.test.ts
+++ b/src/domain/locations/__tests__/Location.test.ts
@@ -124,8 +124,9 @@ describe('Location (domain)', () => {
       expect(() => createLocation(createTestLocationInput({ businessId: '' }))).toThrow(ValidationError);
     });
 
-    it('throws for empty name', () => {
-      expect(() => createLocation(createTestLocationInput({ name: '' }))).toThrow(ValidationError);
+    it('allows empty name', () => {
+      const location = createLocation(createTestLocationInput({ name: '' }));
+      expect(location.name).toBe('');
     });
   });
 });

--- a/src/domain/surfaces/CheckoutOptions.ts
+++ b/src/domain/surfaces/CheckoutOptions.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, baseEntityDefaults } from '../BaseEntity';
-import { requireNonEmptyString } from '../validation';
+import { requireString } from '../validation';
 
 export interface TipOptions {
   isEnabled: boolean;
@@ -73,7 +73,7 @@ export function createCheckoutOptions(input: Partial<CheckoutOptions> & {
   giftCards: GiftCardOptions;
   referralCodes: ReferralCodeOptions;
 }): CheckoutOptions {
-  requireNonEmptyString('name', input.name);
+  requireString('name', input.name);
   return {
     ...baseEntityDefaults(input),
     name: input.name,

--- a/src/domain/surfaces/KioskConfiguration.ts
+++ b/src/domain/surfaces/KioskConfiguration.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, baseEntityDefaults } from '../BaseEntity';
-import { requireNonEmptyString } from '../validation';
+import { requireString } from '../validation';
 
 export interface KioskConfiguration extends BaseEntity {
   name: string;
@@ -9,7 +9,7 @@ export interface KioskConfiguration extends BaseEntity {
 }
 
 export function createKioskConfiguration(input: Partial<KioskConfiguration> & { name: string }): KioskConfiguration {
-  requireNonEmptyString('name', input.name);
+  requireString('name', input.name);
   return {
     ...baseEntityDefaults(input),
     name: input.name,

--- a/src/domain/surfaces/Menu.ts
+++ b/src/domain/surfaces/Menu.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, baseEntityDefaults } from '../BaseEntity';
-import { requireNonEmptyString } from '../validation';
+import { requireString } from '../validation';
 import { MenuGroupMeta } from './MenuGroup';
 
 export interface MenuMeta {
@@ -34,7 +34,7 @@ export interface Menu extends BaseEntity {
 }
 
 export function createMenu(input: MenuInput & Partial<BaseEntity>): Menu {
-  requireNonEmptyString('name', input.name);
+  requireString('name', input.name);
   return {
     ...baseEntityDefaults(input),
     name: input.name,

--- a/src/domain/surfaces/MenuGroup.ts
+++ b/src/domain/surfaces/MenuGroup.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, baseEntityDefaults } from '../BaseEntity';
-import { requireNonEmptyString } from '../validation';
+import { requireString } from '../validation';
 import { ProductMeta } from '../catalog/Product';
 
 export interface MenuGroupMeta {
@@ -30,7 +30,7 @@ export interface MenuGroup extends BaseEntity {
 }
 
 export function createMenuGroup(input: MenuGroupInput & Partial<BaseEntity>): MenuGroup {
-  requireNonEmptyString('name', input.name);
+  requireString('name', input.name);
   return {
     ...baseEntityDefaults(input),
     name: input.name,

--- a/src/domain/surfaces/SurfaceConfiguration.ts
+++ b/src/domain/surfaces/SurfaceConfiguration.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, baseEntityDefaults } from '../BaseEntity';
-import { requireNonEmptyString } from '../validation';
+import { requireString } from '../validation';
 
 export interface CoverConfiguration {
   isCoverNoticeEnabled: boolean;
@@ -46,7 +46,7 @@ export function createSurfaceConfiguration(input: Partial<SurfaceConfiguration> 
   name: string;
   isChargeCustomerServiceFee: boolean;
 }): SurfaceConfiguration {
-  requireNonEmptyString('name', input.name);
+  requireString('name', input.name);
   return {
     ...baseEntityDefaults(input),
     name: input.name,

--- a/src/domain/surfaces/__tests__/CheckoutOptions.test.ts
+++ b/src/domain/surfaces/__tests__/CheckoutOptions.test.ts
@@ -75,8 +75,9 @@ describe('CheckoutOptions (domain)', () => {
   });
 
   describe('validation', () => {
-    it('throws for empty name', () => {
-      expect(() => createCheckoutOptions(createTestCheckoutOptionsInput({ name: '' }))).toThrow(ValidationError);
+    it('allows empty name', () => {
+      const co = createCheckoutOptions(createTestCheckoutOptionsInput({ name: '' }));
+      expect(co.name).toBe('');
     });
   });
 

--- a/src/domain/surfaces/__tests__/KioskConfiguration.test.ts
+++ b/src/domain/surfaces/__tests__/KioskConfiguration.test.ts
@@ -39,8 +39,9 @@ describe('KioskConfiguration (domain)', () => {
   });
 
   describe('validation', () => {
-    it('throws for empty name', () => {
-      expect(() => createKioskConfiguration(createTestKioskConfigurationInput({ name: '' }))).toThrow(ValidationError);
+    it('allows empty name', () => {
+      const kc = createKioskConfiguration(createTestKioskConfigurationInput({ name: '' }));
+      expect(kc.name).toBe('');
     });
   });
 

--- a/src/domain/surfaces/__tests__/Menu.test.ts
+++ b/src/domain/surfaces/__tests__/Menu.test.ts
@@ -93,8 +93,9 @@ describe('Menu (domain)', () => {
   });
 
   describe('validation', () => {
-    it('throws for empty name', () => {
-      expect(() => createMenu(createTestMenuInput({ name: '' }))).toThrow(ValidationError);
+    it('allows empty name', () => {
+      const menu = createMenu(createTestMenuInput({ name: '' }));
+      expect(menu.name).toBe('');
     });
   });
 

--- a/src/domain/surfaces/__tests__/MenuGroup.test.ts
+++ b/src/domain/surfaces/__tests__/MenuGroup.test.ts
@@ -90,8 +90,9 @@ describe('MenuGroup (domain)', () => {
   });
 
   describe('validation', () => {
-    it('throws for empty name', () => {
-      expect(() => createMenuGroup(createTestMenuGroupInput({ name: '' }))).toThrow(ValidationError);
+    it('allows empty name', () => {
+      const mg = createMenuGroup(createTestMenuGroupInput({ name: '' }));
+      expect(mg.name).toBe('');
     });
   });
 

--- a/src/domain/surfaces/__tests__/SurfaceConfiguration.test.ts
+++ b/src/domain/surfaces/__tests__/SurfaceConfiguration.test.ts
@@ -82,8 +82,9 @@ describe('SurfaceConfiguration (domain)', () => {
   });
 
   describe('validation', () => {
-    it('throws for empty name', () => {
-      expect(() => createSurfaceConfiguration(createTestSurfaceConfigurationInput({ name: '' }))).toThrow(ValidationError);
+    it('allows empty name', () => {
+      const sc = createSurfaceConfiguration(createTestSurfaceConfigurationInput({ name: '' }));
+      expect(sc.name).toBe('');
     });
   });
 

--- a/src/domain/validation.ts
+++ b/src/domain/validation.ts
@@ -8,6 +8,12 @@ export class ValidationError extends Error {
   }
 }
 
+export function requireString(field: string, value: unknown): void {
+  if (typeof value !== 'string') {
+    throw new ValidationError(field, 'must be a string');
+  }
+}
+
 export function requireNonEmptyString(field: string, value: unknown): void {
   if (typeof value !== 'string' || value.trim().length === 0) {
     throw new ValidationError(field, 'must be a non-empty string');
@@ -26,12 +32,21 @@ export function requireNonNegativeInteger(field: string, value: unknown): void {
   }
 }
 
+/** Like requireNonNegativeInteger but also allows -1 as a sentinel for "no constraint". */
+export function requireNonNegativeIntegerOrNeg1(field: string, value: unknown): void {
+  if (typeof value !== 'number' || !Number.isInteger(value) || (value < 0 && value !== -1)) {
+    throw new ValidationError(field, 'must be a non-negative integer or -1');
+  }
+}
+
 export function requireMinLessOrEqual(
   minField: string,
   minValue: number,
   maxField: string,
   maxValue: number,
 ): void {
+  // -1 sentinel means "no constraint" — skip comparison when either side is unconstrained
+  if (minValue === -1 || maxValue === -1) return;
   if (minValue > maxValue) {
     throw new ValidationError(
       minField,


### PR DESCRIPTION
## Summary

- Add `requireString` validation guard that accepts empty strings but rejects missing/null/non-string — replaces `requireNonEmptyString` for `name` field on all 13 named entities
- Add `requireNonNegativeIntegerOrNeg1` guard for OptionSet `minSelection`/`maxSelection` where `-1` means "no constraint"
- Update `requireMinLessOrEqual` to skip comparison when either side is `-1`
- Includes full #21 migration (DDD class hierarchy → plain interfaces with factory functions)

## Validation against production data

Validated against **5,882 documents** in Firestore (`project-arya-280418`):

| Collection | Docs | Empty Names | -1 Sentinels |
|---|---|---|---|
| Product | 917 | 0 | n/a |
| Category | 1,439 | 0 | n/a |
| OptionSet | 1,024 | **255 (85% of first 300)** | **33+** |
| Option | 2,076 | **68 (23% of first 300)** | n/a |
| Discount | 424 | 0 | n/a |
| TaxRate | 2 | 0 | n/a |

**Zero validation issues** across all documents — field types, ranges, metadata consistency, required fields, and linkedObjects shape all pass.

## Test plan

- [x] 549 tests pass (`npm test`)
- [x] Field validation against production Firestore (types, ranges, constraints)
- [x] Required fields check (no missing fields that factories require)
- [x] Metadata consistency (Category→Product, OptionSet→Option, Product→OptionSet)
- [x] LinkedObjects shape validation

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)