### PR TITLE
Fix SemaphoreV2.lock() false positive on transaction retry (#31)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Return the boolean from the transaction instead of using a closure variable that persists across retries. Also skip unnecessary writes in release() when the semaphore is already available.