### PR TITLE
Fix totalTipAmount string coercion in orderConverter

### DIFF
--- a/src/persistence/firestore/__tests__/OrderRepository.test.ts
+++ b/src/persistence/firestore/__tests__/OrderRepository.test.ts
@@ -255,6 +255,19 @@ describe('OrderRepository', () => {
     expect(result!.totalTipAmount).toBe(0);
   });
 
+  it('fromFirestore coerces string totalTipAmount to number', async () => {
+    const serialized = createFullSerializedOrder();
+    (serialized as any).totalTipAmount = '100';
+    mockDocRef.get.mockResolvedValue({
+      exists: true,
+      data: () => serialized,
+      id: 'order-1',
+    });
+
+    const result = await repo.get('biz-1', 'order-1');
+    expect(result!.totalTipAmount).toBe(100);
+  });
+
   it('findByLinkedObject() queries correct field path', async () => {
     mockQuery.get.mockResolvedValue({
       docs: [{

--- a/src/persistence/firestore/converters/orderConverter.ts
+++ b/src/persistence/firestore/converters/orderConverter.ts
@@ -10,7 +10,7 @@ export const orderConverter = createConverter<Order>(
     toFirestore: (order) => ({ timestamp: order.timestamp.toISOString() }),
     fromFirestore: (data) => ({
       timestamp: new Date(data.timestamp),
-      totalTipAmount: data.totalTipAmount ?? 0,
+      totalTipAmount: Number(data.totalTipAmount ?? 0),
       referralCode: data.referralCode ?? null,
       source: data.source ?? null,
       tags: data.tags ?? null,


### PR DESCRIPTION
## Summary
- Coerce `totalTipAmount` from string to number in `orderConverter.fromFirestore` using `Number()`, fixing validation failures from corrupted Firestore data written by a now-fixed `BigInt.toString()` bug in square-gateway
- Add test for string-to-number coercion scenario

## Test plan
- [x] `npm test` — all 598 tests pass, including new coercion test
- [x] Verified `Number("100")` → `100` and `Number(0)` → `0` (safe for both corrupted and clean data)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)