### PR TITLE
Fix createMenu() missing defaults for 5 optional fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/domain/surfaces/Menu.ts
+++ b/src/domain/surfaces/Menu.ts
@@ -61,11 +61,11 @@ export interface Menu extends BaseEntity {
   logoImageGsl: string | null;
   gratuityRates: number[];
   managedBy: string | null;
-  collections?: { [id: string]: MenuCollectionMeta };
-  menuAssets?: { [id: string]: MenuAsset };
-  menuAssetDisplayOrder?: string[];
-  version?: string;
-  products?: { [id: string]: MenuProductMeta };
+  collections: { [id: string]: MenuCollectionMeta };
+  menuAssets: { [id: string]: MenuAsset };
+  menuAssetDisplayOrder: string[];
+  version: string | null;
+  products: { [id: string]: MenuProductMeta };
 }
 
 export function createMenu(input: MenuInput & Partial<BaseEntity>): Menu {
@@ -82,11 +82,11 @@ export function createMenu(input: MenuInput & Partial<BaseEntity>): Menu {
     logoImageGsl: input.logoImageGsl ?? null,
     gratuityRates: input.gratuityRates ?? [],
     managedBy: input.managedBy ?? null,
-    collections: input.collections,
-    menuAssets: input.menuAssets,
-    menuAssetDisplayOrder: input.menuAssetDisplayOrder,
-    version: input.version,
-    products: input.products,
+    collections: input.collections ?? {},
+    menuAssets: input.menuAssets ?? {},
+    menuAssetDisplayOrder: input.menuAssetDisplayOrder ?? [],
+    version: input.version ?? null,
+    products: input.products ?? {},
   };
 }
 

--- a/src/domain/surfaces/__tests__/Menu.test.ts
+++ b/src/domain/surfaces/__tests__/Menu.test.ts
@@ -81,6 +81,31 @@ describe('Menu (domain)', () => {
     expect(menu.managedBy).toBeNull();
   });
 
+  it('defaults collections to {}', () => {
+    const menu = createMenu(createTestMenuInput());
+    expect(menu.collections).toEqual({});
+  });
+
+  it('defaults menuAssets to {}', () => {
+    const menu = createMenu(createTestMenuInput());
+    expect(menu.menuAssets).toEqual({});
+  });
+
+  it('defaults menuAssetDisplayOrder to []', () => {
+    const menu = createMenu(createTestMenuInput());
+    expect(menu.menuAssetDisplayOrder).toEqual([]);
+  });
+
+  it('defaults version to null', () => {
+    const menu = createMenu(createTestMenuInput());
+    expect(menu.version).toBeNull();
+  });
+
+  it('defaults products to {}', () => {
+    const menu = createMenu(createTestMenuInput());
+    expect(menu.products).toEqual({});
+  });
+
   it('menuMeta() returns MenuMeta', () => {
     const menu = createMenu(createTestMenuInput({
       name: 'Dinner',


### PR DESCRIPTION
## Summary
- Add nullish coalescing defaults for `collections`, `menuAssets`, `menuAssetDisplayOrder`, `version`, and `products` in `createMenu()` to prevent Firestore `undefined` value errors
- Make these fields non-optional on the `Menu` interface (they now always have values, matching the existing pattern for `groups`, `groupDisplayOrder`, etc.)
- Bump version to 1.5.1

## Test plan
- [x] `npm test` — all 603 tests pass (5 new)
- [x] `npm run tsc` — clean compilation

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)