### PR TITLE
Move semaphores to top-level Firestore collection

### DIFF
--- a/archive/ISSUE_44_PLAN.md
+++ b/archive/ISSUE_44_PLAN.md
@@ -1,0 +1,43 @@
+# Issue #44: Denormalize semaphores to top-level Firestore collection
+
+## Context
+
+Semaphores (`catalogUpdate`, `locationUpdate`) are currently stored at `businesses/{businessId}/private/vars/semaphores/{semaphoreName}`. This deeply nested path shares a prefix with all other business data, causing write contention during catalog/location syncs. Moving to a top-level `semaphores/{businessId}_{semaphoreName}` collection isolates semaphore traffic onto independent Firestore storage nodes.
+
+## Changes
+
+### 1. `src/firestore-core/Paths.ts`
+- Add a new top-level collection name constant (e.g., `topLevelSemaphores = 'semaphores'`) to avoid collision with the existing `semaphores` enum value used for the nested subcollection name
+- Keep the existing `semaphores` value since it's the subcollection name (no longer referenced by PathResolver after the change, but safe to leave)
+
+### 2. `src/persistence/firestore/PathResolver.ts`
+- Change `semaphoresCollection()` to remove the `businessId` parameter and return the top-level collection:
+  ```typescript
+  static semaphoresCollection(): FirebaseFirestore.CollectionReference {
+    return this.db().collection(Paths.CollectionNames.topLevelSemaphores);
+  }
+  ```
+
+### 3. `src/restaurant/vars/SemaphoreV2.ts`
+- Update `ref()` to compose the document ID as `{businessId}_{type}`:
+  ```typescript
+  static ref(businessId: string, type: string) {
+    return PathResolver.semaphoresCollection().doc(`${businessId}_${type}`);
+  }
+  ```
+- No other changes — `lock()`, `release()`, and `firestoreConverter` work unchanged since they operate on the doc reference returned by `ref()`
+
+### 4. Tests
+
+#### `src/persistence/firestore/__tests__/PathResolver.test.ts`
+- Update the `semaphoresCollection` test to assert the new top-level path `semaphores` and remove the businessId argument
+
+#### `src/restaurant/vars/__tests__/SemaphoreV2.test.ts`
+- Update `mockDocRef.path` from `businesses/biz-1/private/vars/semaphores/catalog` to `semaphores/biz-1_catalog`
+- Update the `ref()` test: `semaphoresCollection` mock is called with no args, and `mockCollectionRef.doc` is called with `'biz-1_catalog'`
+
+## Verification
+
+1. Run `npm test` — all tests pass
+2. Run `npm run tsc` — compiles cleanly
+3. Run `npx eslint src/` — no lint errors

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kiosinc/restaurant-core-claude",
-      "version": "1.5.0",
+      "version": "1.5.2",
       "license": "ISC",
       "devDependencies": {
         "@google-cloud/functions-framework": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/firestore-core/Paths.ts
+++ b/src/firestore-core/Paths.ts
@@ -32,7 +32,6 @@ export enum CollectionNames {
   checkoutOptions = 'checkoutOptions',
   collections = 'collections',
   services = 'services',
-  semaphores = 'semaphores',
   inventory = 'inventory',
 
   orders = 'orders',
@@ -40,4 +39,6 @@ export enum CollectionNames {
 
   onboarding = 'onboarding',
   onboardingOrders = 'onboardingOrders',
+
+  semaphores = 'semaphores',
 }

--- a/src/persistence/firestore/PathResolver.ts
+++ b/src/persistence/firestore/PathResolver.ts
@@ -150,7 +150,7 @@ export class PathResolver {
     return this.onboardingDoc(businessId).collection(Paths.CollectionNames.onboardingOrders);
   }
 
-  static semaphoresCollection(businessId: string): FirebaseFirestore.CollectionReference {
-    return this.varsDoc(businessId).collection(Paths.CollectionNames.semaphores);
+  static semaphoresCollection(): FirebaseFirestore.CollectionReference {
+    return this.db().collection(Paths.CollectionNames.semaphores);
   }
 }

--- a/src/persistence/firestore/__tests__/PathResolver.test.ts
+++ b/src/persistence/firestore/__tests__/PathResolver.test.ts
@@ -123,7 +123,7 @@ describe('PathResolver', () => {
   });
 
   it('semaphoresCollection returns correct path', () => {
-    PathResolver.semaphoresCollection('biz-1');
-    expect(lastPath).toBe('businesses/biz-1/private/vars/semaphores');
+    PathResolver.semaphoresCollection();
+    expect(lastPath).toBe('semaphores');
   });
 });

--- a/src/restaurant/vars/SemaphoreV2.ts
+++ b/src/restaurant/vars/SemaphoreV2.ts
@@ -31,7 +31,7 @@ export default class Semaphore {
   }
 
   static ref(businessId: string, type: string) {
-    return PathResolver.semaphoresCollection(businessId).doc(type);
+    return PathResolver.semaphoresCollection().doc(`${businessId}_${type}`);
   }
 
   static async lock(

--- a/src/restaurant/vars/__tests__/SemaphoreV2.test.ts
+++ b/src/restaurant/vars/__tests__/SemaphoreV2.test.ts
@@ -8,7 +8,7 @@ const mockTransaction = {
 };
 
 const mockDocRef = {
-  path: 'businesses/biz-1/private/vars/semaphores/catalog',
+  path: 'semaphores/biz-1_catalog',
 };
 
 const mockCollectionRef = {
@@ -41,8 +41,8 @@ describe('SemaphoreV2', () => {
   describe('ref()', () => {
     it('constructs correct Firestore path via PathResolver', () => {
       Semaphore.ref('biz-1', 'catalog');
-      expect(PathResolver.semaphoresCollection).toHaveBeenCalledWith('biz-1');
-      expect(mockCollectionRef.doc).toHaveBeenCalledWith('catalog');
+      expect(PathResolver.semaphoresCollection).toHaveBeenCalledWith();
+      expect(mockCollectionRef.doc).toHaveBeenCalledWith('biz-1_catalog');
     });
   });
 


### PR DESCRIPTION
## Summary
- Moves semaphore documents from `businesses/{bid}/private/vars/semaphores/{type}` to a top-level `semaphores/{bid}_{type}` collection
- Eliminates write contention by isolating semaphore traffic from business data storage nodes
- Bumps version to 1.5.2

## Test plan
- [x] `npm test` — all tests pass
- [x] `npm run tsc` — compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)