### PR TITLE
feat: add allergen, dietary preference, and calorie fields to Product domain model

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,39 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kiosinc/restaurant-core-claude",
-      "version": "1.9.3",
+      "version": "1.10.0",
       "license": "ISC",
       "devDependencies": {
         "@google-cloud/functions-framework": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.9.4",
+  "version": "1.10.0",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/domain/catalog/Product.ts
+++ b/src/domain/catalog/Product.ts
@@ -12,6 +12,9 @@ export interface ProductMeta {
   minPrice: number;
   maxPrice: number;
   variationCount: number;
+  dietaryPreferences?: string[];
+  allergens?: string[];
+  calorieCount?: number;
 }
 
 export interface ProductInput {
@@ -28,6 +31,9 @@ export interface ProductInput {
   locationInventory?: LocationInventoryMap;
   isActive: boolean;
   linkedObjects?: LinkedObjectMap;
+  dietaryPreferences?: string[];
+  allergens?: string[];
+  calorieCount?: number;
 }
 
 export interface Product extends BaseEntity {
@@ -44,6 +50,9 @@ export interface Product extends BaseEntity {
   locationInventory: LocationInventoryMap;
   isActive: boolean;
   linkedObjects: LinkedObjectMap;
+  dietaryPreferences: string[];
+  allergens: string[];
+  calorieCount?: number;
 }
 
 export function createProduct(input: ProductInput & Partial<BaseEntity>): Product {
@@ -67,6 +76,9 @@ export function createProduct(input: ProductInput & Partial<BaseEntity>): Produc
     locationInventory: input.locationInventory ?? {},
     isActive: input.isActive,
     linkedObjects: input.linkedObjects ?? {},
+    dietaryPreferences: input.dietaryPreferences ?? [],
+    allergens: input.allergens ?? [],
+    calorieCount: input.calorieCount,
   };
 }
 
@@ -79,5 +91,8 @@ export function productMeta(product: Product): ProductMeta {
     minPrice: product.minPrice,
     maxPrice: product.maxPrice,
     variationCount: product.variationCount,
+    dietaryPreferences: product.dietaryPreferences,
+    allergens: product.allergens,
+    ...(product.calorieCount !== undefined && { calorieCount: product.calorieCount }),
   };
 }

--- a/src/domain/catalog/__tests__/Product.test.ts
+++ b/src/domain/catalog/__tests__/Product.test.ts
@@ -96,6 +96,8 @@ describe('Product (domain)', () => {
       minPrice: 1000,
       maxPrice: 1500,
       variationCount: 2,
+      dietaryPreferences: [],
+      allergens: [],
     });
   });
 

--- a/src/domain/services/__tests__/CatalogCascadeService.test.ts
+++ b/src/domain/services/__tests__/CatalogCascadeService.test.ts
@@ -29,6 +29,7 @@ describe('CatalogCascadeService', () => {
           name: 'Burger', isActive: true,
           imageUrls: ['b.jpg'], imageGsls: [],
           minPrice: 500, maxPrice: 800, variationCount: 3,
+          dietaryPreferences: [], allergens: [],
         },
       });
       expect(result[0].update.fieldsToDelete).toEqual([]);
@@ -65,6 +66,7 @@ describe('CatalogCascadeService', () => {
           name: 'Burger', isActive: true,
           imageUrls: ['b.jpg'], imageGsls: [],
           minPrice: 500, maxPrice: 800, variationCount: 3,
+          dietaryPreferences: [], allergens: [],
         },
       });
       expect(result[0].update.fieldsToDelete).toEqual([]);

--- a/src/persistence/firestore/__tests__/ProductRepository.test.ts
+++ b/src/persistence/firestore/__tests__/ProductRepository.test.ts
@@ -18,6 +18,7 @@ function createFullSerializedProduct() {
     minPrice: 500, maxPrice: 800, variationCount: 3,
     locationInventory: { 'loc-1': { count: 5, state: 'instock', isAvailable: true } },
     isActive: true, linkedObjects: { square: { linkedObjectId: 'sq-1' } },
+    dietaryPreferences: ['VEGAN'], allergens: ['PEANUTS'], calorieCount: 450,
     created: ts, updated: ts, isDeleted: false,
   };
 }
@@ -86,6 +87,33 @@ describe('ProductRepository', () => {
     expect(restored!.name).toBe(original.name);
     expect(restored!.caption).toBe(original.caption);
     expect(restored!.minPrice).toBe(original.minPrice);
+  });
+
+  it('round-trip preserves allergen fields', async () => {
+    const original = createProduct(createTestProductInput({
+      dietaryPreferences: ['VEGAN', 'GLUTEN_FREE'],
+      allergens: ['PEANUTS', 'MILK'],
+      calorieCount: 320,
+    }));
+    await repo.set(original, 'biz-1');
+    const serialized = mockTransaction.set.mock.calls[0][1];
+    mockDocRef.get.mockResolvedValue({ exists: true, data: () => serialized, id: original.Id });
+    const restored = await repo.get('biz-1', original.Id);
+    expect(restored!.dietaryPreferences).toEqual(['VEGAN', 'GLUTEN_FREE']);
+    expect(restored!.allergens).toEqual(['PEANUTS', 'MILK']);
+    expect(restored!.calorieCount).toBe(320);
+  });
+
+  it('fromFirestore defaults allergen arrays to []', async () => {
+    const data = createFullSerializedProduct();
+    delete (data as any).dietaryPreferences;
+    delete (data as any).allergens;
+    delete (data as any).calorieCount;
+    mockDocRef.get.mockResolvedValue({ exists: true, data: () => data, id: 'prod-1' });
+    const result = await repo.get('biz-1', 'prod-1');
+    expect(result!.dietaryPreferences).toEqual([]);
+    expect(result!.allergens).toEqual([]);
+    expect(result!.calorieCount).toBeUndefined();
   });
 
   it('fromFirestore defaults caption to empty string', async () => {

--- a/src/persistence/firestore/handlers/__tests__/CascadeRelationshipHandler.test.ts
+++ b/src/persistence/firestore/handlers/__tests__/CascadeRelationshipHandler.test.ts
@@ -63,6 +63,7 @@ describe('ProductRelationshipHandler', () => {
         name: 'Burger', isActive: true,
         imageUrls: ['b.jpg'], imageGsls: [],
         minPrice: 500, maxPrice: 800, variationCount: 3,
+        dietaryPreferences: [], allergens: [],
       },
     });
   });
@@ -146,6 +147,7 @@ describe('ProductMenuGroupRelationshipHandler', () => {
         name: 'Burger', isActive: true,
         imageUrls: ['b.jpg'], imageGsls: [],
         minPrice: 500, maxPrice: 800, variationCount: 3,
+        dietaryPreferences: [], allergens: [],
       },
     });
   });


### PR DESCRIPTION
Closes #60

## Summary

- Adds `dietaryPreferences: string[]`, `allergens: string[]`, `calorieCount?: number` to `ProductInput`, `Product`, and `ProductMeta`
- `createProduct()` defaults arrays to `[]`; `calorieCount` is `undefined` when absent
- `productMeta()` always emits `dietaryPreferences`/`allergens` (ensures cascade clears stale values); `calorieCount` omitted when `undefined`
- Converter serialization works via existing spread in `converterFactory.ts` — no converter changes needed
- Version bump: `1.9.4` → `1.10.0` (minor, non-breaking — all fields optional on input)

## Context

square-gateway-claude#83 (already deployed) extracts allergen data from Square and assigns it to the Product object. The `toFirestore` converter spread writes it to Firestore. However, `createProduct()` didn't map these fields on read-back, so they were silently dropped on round-trip. A module-augmentation workaround in `square-gateway-claude/src/global.d.ts` kept TypeScript happy in the meantime. This PR makes it official and removes the need for that workaround.

## What changed

| File | Change |
|---|---|
| `src/domain/catalog/Product.ts` | Add fields to `ProductInput`, `Product`, `ProductMeta`, `createProduct()`, `productMeta()` |
| `src/domain/catalog/__tests__/Product.test.ts` | Update `productMeta()` expectation |
| `src/domain/services/__tests__/CatalogCascadeService.test.ts` | Update cascade metadata expectations |
| `src/persistence/firestore/__tests__/ProductRepository.test.ts` | Add allergen round-trip + defaults tests |
| `src/persistence/firestore/handlers/__tests__/CascadeRelationshipHandler.test.ts` | Update ProductMeta cascade expectations |
| `.github/workflows/claude.yml` | Add Claude Code Action |
| `package.json` / `package-lock.json` | Bump to 1.10.0 |

## Rebase note

Branch was rebased cleanly from scratch onto current `master` (at 1.9.4). Previous `issue/60` history (branched from 0.0.x) is replaced by a single clean commit.

## Test plan

- [x] 682/682 tests passing (`npm test`)
- [x] TypeScript type check passes
- [ ] After merge + publish: remove module-augmentation workaround in `square-gateway-claude/src/global.d.ts` and bump dep to `^1.10.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)