### PR TITLE
P13-availability-doc [feat]: extend ProductAvailability and add getOptionTimestamp (#67)

### DIFF
--- a/.archive/ISSUE_67.md
+++ b/.archive/ISSUE_67.md
@@ -1,0 +1,182 @@
+# Implementation Plan: P13-availability-doc (#67)
+
+## Overview
+
+Three categories of change:
+1. **Type changes** — extend `ProductAvailability` with `state`/`timestamp`; tighten `OptionAvailability.state` to union
+2. **New helper** — add `getOptionTimestamp` (returns `Date | undefined`, per issue spec)
+3. **Test updates** — fix `'IN_STOCK'` → `'inStock'`; add 4 + 1 new tests
+4. **Version bump** — `1.8.1` → `1.9.0`
+
+---
+
+## Group A: `src/domain/services/AvailabilityService.ts`
+
+### A1. Extend `ProductAvailability`
+```ts
+export interface ProductAvailability {
+  isAvailable: boolean;
+  state?: 'inStock' | 'soldOut';
+  timestamp?: string;
+}
+```
+Both new fields optional — backwards-compatible. Existing callers that pass only `{ isAvailable: true }` continue to compile.
+
+### A2. Tighten `OptionAvailability.state`
+Change line 10:
+```ts
+// Before
+state: string;
+// After
+state: 'inStock' | 'soldOut';
+```
+
+### A3. Add `getOptionTimestamp`
+Add at bottom of `AvailabilityService.ts` (after `updateAvailability`):
+
+```ts
+export async function getOptionTimestamp(
+  businessId: string,
+  locationId: string,
+  optionId: string,
+): Promise<Date | undefined> {
+  const docRef = PathResolver.availabilityDoc(businessId, locationId);
+  const snap = await docRef.get();
+  if (!snap.exists) return undefined;
+  const opt = snap.data()?.options?.[optionId];
+  return opt?.timestamp ? new Date(opt.timestamp) : undefined;
+}
+```
+
+Returns `Date | undefined` (not `string | null`) — exact shape from issue spec. Callers (square-gateway-claude) compare against a `Date`.
+
+---
+
+## Group B: `src/domain/services/index.ts`
+
+Add `getOptionTimestamp` to the re-export block:
+```ts
+export {
+  ProductAvailability,
+  OptionAvailability,
+  AvailabilityDoc,
+  getAvailability,
+  setProductAvailability,
+  setOptionAvailability,
+  setProductAvailabilityBatch,
+  updateAvailability,
+  getOptionTimestamp,   // ← add
+} from './AvailabilityService';
+```
+
+---
+
+## Group C: `src/domain/services/__tests__/AvailabilityService.test.ts`
+
+### C1. Add `getOptionTimestamp` to import
+
+### C2. Replace `'IN_STOCK'` → `'inStock'` (5 occurrences)
+- Line 41: mock data in `getAvailability` test
+- Lines 79, 89: `setOptionAvailability` test input + expected assertion
+- Lines 119, 124: `updateAvailability` test input + expected assertion
+
+### C3. New `describe('getOptionTimestamp')` block (4 tests)
+
+```ts
+describe('getOptionTimestamp', () => {
+  it('returns undefined when doc does not exist', async () => {
+    mockDocGet.mockResolvedValue({ exists: false });
+    const result = await getOptionTimestamp('biz-1', 'loc-1', 'opt-1');
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when option is not in the doc', async () => {
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ options: {} }),
+    });
+    const result = await getOptionTimestamp('biz-1', 'loc-1', 'opt-missing');
+    expect(result).toBeUndefined();
+  });
+
+  it('returns a Date when option exists with a timestamp', async () => {
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        options: {
+          'opt-1': { isAvailable: true, count: 3, state: 'inStock', timestamp: '2024-06-01T12:00:00Z' },
+        },
+      }),
+    });
+    const result = await getOptionTimestamp('biz-1', 'loc-1', 'opt-1');
+    expect(result).toEqual(new Date('2024-06-01T12:00:00Z'));
+  });
+
+  it('returns undefined when option exists but has no timestamp', async () => {
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        options: {
+          'opt-1': { isAvailable: true, count: 3, state: 'inStock' },
+        },
+      }),
+    });
+    const result = await getOptionTimestamp('biz-1', 'loc-1', 'opt-1');
+    expect(result).toBeUndefined();
+  });
+});
+```
+
+### C4. New test in `describe('setProductAvailability')` — state/timestamp merge write
+
+```ts
+it('writes state and timestamp fields via merge when provided', async () => {
+  await setProductAvailability('biz-1', 'loc-1', 'prod-1', {
+    isAvailable: false,
+    state: 'soldOut',
+    timestamp: '2024-06-01T09:00:00Z',
+  });
+
+  expect(mockDocSet).toHaveBeenCalledWith(
+    {
+      'products.prod-1': {
+        isAvailable: false,
+        state: 'soldOut',
+        timestamp: '2024-06-01T09:00:00Z',
+      },
+    },
+    { merge: true },
+  );
+});
+```
+
+---
+
+## Group D: `package.json`
+
+Bump `"version": "1.8.1"` → `"version": "1.9.0"`.
+
+---
+
+## Checklist
+
+### Group A — AvailabilityService.ts
+- [ ] Add `state?: 'inStock' | 'soldOut'` to `ProductAvailability`
+- [ ] Add `timestamp?: string` to `ProductAvailability`
+- [ ] Change `OptionAvailability.state` from `string` to `'inStock' | 'soldOut'`
+- [ ] Add exported `getOptionTimestamp(businessId, locationId, optionId): Promise<Date | undefined>`
+
+### Group B — index.ts
+- [ ] Add `getOptionTimestamp` to re-export block
+
+### Group C — AvailabilityService.test.ts
+- [ ] Add `getOptionTimestamp` to import
+- [ ] Replace all 5 `'IN_STOCK'` occurrences with `'inStock'`
+- [ ] Add test: `getOptionTimestamp` returns `undefined` when doc missing
+- [ ] Add test: `getOptionTimestamp` returns `undefined` when option missing
+- [ ] Add test: `getOptionTimestamp` returns `Date` when option has timestamp
+- [ ] Add test: `getOptionTimestamp` returns `undefined` when option has no timestamp
+- [ ] Add test: `setProductAvailability` writes `state`/`timestamp` via merge
+
+### Group D — package.json
+- [ ] Bump version `1.8.1` → `1.9.0`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.8.1",
+  "version": "1.9.0",
 
   "description": "",
   "main": "lib/index.js",

--- a/src/domain/services/AvailabilityService.ts
+++ b/src/domain/services/AvailabilityService.ts
@@ -95,9 +95,7 @@ export async function getOptionTimestamp(
   locationId: string,
   optionId: string,
 ): Promise<Date | undefined> {
-  const docRef = PathResolver.availabilityDoc(businessId, locationId);
-  const snap = await docRef.get();
-  if (!snap.exists) return undefined;
-  const opt = snap.data()?.options?.[optionId];
-  return opt?.timestamp ? new Date(opt.timestamp) : undefined;
+  const doc = await getAvailability(businessId, locationId);
+  const ts = doc?.options?.[optionId]?.timestamp;
+  return ts ? new Date(ts) : undefined;
 }

--- a/src/domain/services/AvailabilityService.ts
+++ b/src/domain/services/AvailabilityService.ts
@@ -2,12 +2,14 @@ import { PathResolver } from '../../persistence/firestore/PathResolver';
 
 export interface ProductAvailability {
   isAvailable: boolean;
+  state?: 'inStock' | 'soldOut';
+  timestamp?: string;
 }
 
 export interface OptionAvailability {
   isAvailable: boolean;
   count: number;
-  state: string;
+  state: 'inStock' | 'soldOut';
   timestamp: string;
 }
 
@@ -86,4 +88,16 @@ export async function updateAvailability(
     const docRef = PathResolver.availabilityDoc(businessId, locationId);
     await docRef.set(dotUpdates, { merge: true });
   }
+}
+
+export async function getOptionTimestamp(
+  businessId: string,
+  locationId: string,
+  optionId: string,
+): Promise<Date | undefined> {
+  const docRef = PathResolver.availabilityDoc(businessId, locationId);
+  const snap = await docRef.get();
+  if (!snap.exists) return undefined;
+  const opt = snap.data()?.options?.[optionId];
+  return opt?.timestamp ? new Date(opt.timestamp) : undefined;
 }

--- a/src/domain/services/__tests__/AvailabilityService.test.ts
+++ b/src/domain/services/__tests__/AvailabilityService.test.ts
@@ -5,6 +5,7 @@ import {
   setOptionAvailability,
   setProductAvailabilityBatch,
   updateAvailability,
+  getOptionTimestamp,
 } from '../AvailabilityService';
 
 const mockDocGet = vi.fn();
@@ -37,7 +38,7 @@ describe('AvailabilityService', () => {
         exists: true,
         data: () => ({
           products: { 'prod-1': { isAvailable: true } },
-          options: { 'opt-1': { isAvailable: true, count: 5, state: 'IN_STOCK', timestamp: '2024-01-01T00:00:00Z' } },
+          options: { 'opt-1': { isAvailable: true, count: 5, state: 'inStock', timestamp: '2024-01-01T00:00:00Z' } },
         }),
       });
 
@@ -69,6 +70,25 @@ describe('AvailabilityService', () => {
         { merge: true },
       );
     });
+
+    it('writes state and timestamp fields via merge when provided', async () => {
+      await setProductAvailability('biz-1', 'loc-1', 'prod-1', {
+        isAvailable: false,
+        state: 'soldOut',
+        timestamp: '2024-06-01T09:00:00Z',
+      });
+
+      expect(mockDocSet).toHaveBeenCalledWith(
+        {
+          'products.prod-1': {
+            isAvailable: false,
+            state: 'soldOut',
+            timestamp: '2024-06-01T09:00:00Z',
+          },
+        },
+        { merge: true },
+      );
+    });
   });
 
   describe('setOptionAvailability', () => {
@@ -76,7 +96,7 @@ describe('AvailabilityService', () => {
       await setOptionAvailability('biz-1', 'loc-1', 'opt-1', {
         isAvailable: true,
         count: 10,
-        state: 'IN_STOCK',
+        state: 'inStock',
         timestamp: '2024-01-01T00:00:00Z',
       });
 
@@ -85,7 +105,7 @@ describe('AvailabilityService', () => {
           'options.opt-1': {
             isAvailable: true,
             count: 10,
-            state: 'IN_STOCK',
+            state: 'inStock',
             timestamp: '2024-01-01T00:00:00Z',
           },
         },
@@ -115,13 +135,13 @@ describe('AvailabilityService', () => {
     it('writes products and options in a single merge', async () => {
       await updateAvailability('biz-1', 'loc-1', {
         products: { 'prod-1': { isAvailable: true } },
-        options: { 'opt-1': { isAvailable: true, count: 5, state: 'IN_STOCK', timestamp: '2024-01-01T00:00:00Z' } },
+        options: { 'opt-1': { isAvailable: true, count: 5, state: 'inStock', timestamp: '2024-01-01T00:00:00Z' } },
       });
 
       expect(mockDocSet).toHaveBeenCalledWith(
         {
           'products.prod-1': { isAvailable: true },
-          'options.opt-1': { isAvailable: true, count: 5, state: 'IN_STOCK', timestamp: '2024-01-01T00:00:00Z' },
+          'options.opt-1': { isAvailable: true, count: 5, state: 'inStock', timestamp: '2024-01-01T00:00:00Z' },
         },
         { merge: true },
       );
@@ -142,6 +162,49 @@ describe('AvailabilityService', () => {
       await updateAvailability('biz-1', 'loc-1', {});
 
       expect(mockDocSet).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getOptionTimestamp', () => {
+    it('returns undefined when doc does not exist', async () => {
+      mockDocGet.mockResolvedValue({ exists: false });
+      const result = await getOptionTimestamp('biz-1', 'loc-1', 'opt-1');
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when option is not in the doc', async () => {
+      mockDocGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ options: {} }),
+      });
+      const result = await getOptionTimestamp('biz-1', 'loc-1', 'opt-missing');
+      expect(result).toBeUndefined();
+    });
+
+    it('returns a Date when option exists with a timestamp', async () => {
+      mockDocGet.mockResolvedValue({
+        exists: true,
+        data: () => ({
+          options: {
+            'opt-1': { isAvailable: true, count: 3, state: 'inStock', timestamp: '2024-06-01T12:00:00Z' },
+          },
+        }),
+      });
+      const result = await getOptionTimestamp('biz-1', 'loc-1', 'opt-1');
+      expect(result).toEqual(new Date('2024-06-01T12:00:00Z'));
+    });
+
+    it('returns undefined when option exists but has no timestamp', async () => {
+      mockDocGet.mockResolvedValue({
+        exists: true,
+        data: () => ({
+          options: {
+            'opt-1': { isAvailable: true, count: 3, state: 'inStock' },
+          },
+        }),
+      });
+      const result = await getOptionTimestamp('biz-1', 'loc-1', 'opt-1');
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/src/domain/services/index.ts
+++ b/src/domain/services/index.ts
@@ -37,4 +37,5 @@ export {
   setOptionAvailability,
   setProductAvailabilityBatch,
   updateAvailability,
+  getOptionTimestamp,
 } from './AvailabilityService';


### PR DESCRIPTION
Closes #67

## Scope

**In:**
- `ProductAvailability` extended with optional `state: 'inStock' | 'soldOut'` and `timestamp?: string`
- `OptionAvailability.state` tightened from `string` to `'inStock' | 'soldOut'` union
- `getOptionTimestamp(businessId, locationId, optionId): Promise<Date | undefined>` exported — reuses `getAvailability`, no extra Firestore read
- Version bumped `1.8.1` → `1.9.0`

**Out:**
- Updating callers (lives in square-gateway-claude#144)
- Removing legacy `InventoryCount` type / converters (deferred to retirement project)
- Firestore security rules (already in place)

## Summary
- Adds the two fields `square-gateway-claude#144` needs to write and read product availability state
- `getOptionTimestamp` is the staleness-check helper that fixes the silent out-of-order webhook bug (consumed by repo 3)
- All 5 `'IN_STOCK'` uppercase literals in tests replaced with canonical `'inStock'`

## Test plan
- [x] Automated tests pass (678/678)
- [ ] Verify `@kiosinc/restaurant-core-claude@1.9.0` published to Artifact Registry after merge to `dev` (CI)

Generated with [Claude Code](https://claude.com/claude-code)