### PR TITLE
fix(rebuild): filter ghost IDs from groupDisplayOrder and productDisplayOrder (#74)

### DIFF
--- a/.archive/ISSUE_74.md
+++ b/.archive/ISSUE_74.md
@@ -1,0 +1,41 @@
+## Implementation Plan: Ghost ID Cleanup in `MenuRebuildService`
+
+### Checklist
+
+**`src/domain/services/MenuRebuildService.ts`**
+- [ ] Fix Bug 1: replace line 308 `groupDisplayOrder: existingData.groupDisplayOrder ?? []` with filtered version using `id in materializedGroups`
+- [ ] Fix Bug 2: insert `productDisplayOrder` filter after line 160 (after both direct and mirror-category assignment paths), inside `materializeGroups`
+
+**`src/domain/services/__tests__/MenuRebuildService.test.ts`**
+- [ ] Extend "skips deleted groups": add `expect(transactionSets[0].data.groupDisplayOrder).toEqual([])` after the existing `groups` assertion
+- [ ] New test: "removes soft-deleted product from productDisplayOrder"
+- [ ] New test: "removes hard-deleted (absent) product from productDisplayOrder"
+
+**Verification**
+- [ ] `npx tsc --noEmit` passes
+- [ ] `npm test` passes
+
+### Fix 1 (line 308 in `attemptRebuild`)
+```typescript
+// BEFORE
+groupDisplayOrder: existingData.groupDisplayOrder ?? [],
+
+// AFTER
+groupDisplayOrder: (existingData.groupDisplayOrder ?? []).filter(
+  (id: string) => id in materializedGroups
+),
+```
+
+### Fix 2 (insert after line 160 in `materializeGroups`, after both assignment paths)
+```typescript
+productDisplayOrder = productDisplayOrder.filter((pid) => {
+  const product = productMap.get(pid);
+  return product !== undefined && !product.data.isDeleted;
+});
+```
+Line 259 (`const displayOrder = validProductIds(...)`) in `attemptRebuild` must NOT be changed — it collects IDs for batchGetDocs.
+
+### New Tests (in `describe('edge cases')`)
+- Extend "skips deleted groups": add `expect(transactionSets[0].data.groupDisplayOrder).toEqual([])`
+- Soft-deleted product test: group with `productDisplayOrder: ['liveProduct', 'deletedProduct']`, deletedProduct has `isDeleted: true` → assert only `liveProduct` in rebuilt group's productDisplayOrder
+- Hard-deleted product test: same but absentProduct not registered in mock → assert only presentProduct in rebuilt group's productDisplayOrder

--- a/src/domain/services/MenuRebuildService.ts
+++ b/src/domain/services/MenuRebuildService.ts
@@ -159,10 +159,14 @@ function materializeGroups(
       }
     }
 
+    productDisplayOrder = productDisplayOrder.filter((pid) => {
+      const product = productMap.get(pid);
+      return product !== undefined && !product.data.isDeleted;
+    });
+
     const groupProducts: Record<string, MenuProductMeta> = {};
     for (const pid of productDisplayOrder) {
-      const product = productMap.get(pid);
-      if (!product || product.data.isDeleted) continue;
+      const product = productMap.get(pid)!;
       groupProducts[pid] = {
         isActive: product.data.isActive ?? false,
         name: product.data.name ?? '',
@@ -305,7 +309,9 @@ async function attemptRebuild(
 
       // Materialized sections
       groups: materializedGroups,
-      groupDisplayOrder: existingData.groupDisplayOrder ?? [],
+      groupDisplayOrder: (existingData.groupDisplayOrder ?? []).filter(
+        (id: string) => id in materializedGroups
+      ),
       collections: materializedCollections,
       menuAssets: existingData.menuAssets ?? {},
       menuAssetDisplayOrder: existingData.menuAssetDisplayOrder ?? [],

--- a/src/domain/services/__tests__/MenuRebuildService.test.ts
+++ b/src/domain/services/__tests__/MenuRebuildService.test.ts
@@ -400,6 +400,7 @@ describe('MenuRebuildService', () => {
       await rebuildMenus(BUSINESS_ID);
       expect(transactionSets).toHaveLength(1);
       expect(transactionSets[0].data.groups).toEqual({});
+      expect(transactionSets[0].data.groupDisplayOrder).toEqual([]);
     });
 
     it('includes menu group added without legacy assetId field', async () => {
@@ -444,6 +445,80 @@ describe('MenuRebuildService', () => {
       expect(transactionSets).toHaveLength(3);
       const menuIds = transactionSets.map((s) => s.ref._docId).sort();
       expect(menuIds).toEqual(['CcUqgkBxEnk1qYaNZ3K2', 'LShRjmDOXBNL7yVSD65V', 'TdGQqmNhA3AjNeoyYrQn'].sort());
+    });
+
+    it('removes soft-deleted product from productDisplayOrder', async () => {
+      registerCollection(MENU_GROUPS_PATH, [
+        {
+          id: 'gA',
+          data: {
+            name: 'Group A', displayName: 'Group A', imageGsls: [],
+            productDisplayOrder: ['liveProduct', 'deletedProduct'],
+            mirrorCategoryId: null, isDeleted: false,
+          },
+        },
+      ]);
+      registerCollection(PRODUCTS_PATH, [
+        { id: 'liveProduct', data: { name: 'Live', isActive: true, imageGsls: [], minPrice: 500, variationCount: 1, description: '', isDeleted: false } },
+        { id: 'deletedProduct', data: { name: 'Dead', isActive: true, imageGsls: [], minPrice: 500, variationCount: 1, description: '', isDeleted: true } },
+      ]);
+      registerCollection(MENUS_PATH, [{
+        id: 'mA',
+        data: {
+          name: 'Test Menu', displayName: null, coverImageGsl: null,
+          coverBackgroundImageGsl: null, coverVideoGsl: null, logoImageGsl: null,
+          gratuityRates: [], managedBy: null, isDeleted: false,
+          created: new Date(), updated: new Date(), version: '1.0',
+          groupDisplayOrder: ['gA'],
+          groups: {},
+          menuAssets: { gA: { assetType: 'group' } },
+          menuAssetDisplayOrder: ['gA'],
+        },
+      }]);
+
+      await rebuildMenus(BUSINESS_ID);
+
+      expect(transactionSets).toHaveLength(1);
+      const group = transactionSets[0].data.groups['gA'];
+      expect(group.productDisplayOrder).toEqual(['liveProduct']);
+      expect(group.products['deletedProduct']).toBeUndefined();
+    });
+
+    it('removes hard-deleted (absent) product from productDisplayOrder', async () => {
+      registerCollection(MENU_GROUPS_PATH, [
+        {
+          id: 'gB',
+          data: {
+            name: 'Group B', displayName: 'Group B', imageGsls: [],
+            productDisplayOrder: ['presentProduct', 'absentProduct'],
+            mirrorCategoryId: null, isDeleted: false,
+          },
+        },
+      ]);
+      registerCollection(PRODUCTS_PATH, [
+        { id: 'presentProduct', data: { name: 'Present', isActive: true, imageGsls: [], minPrice: 100, variationCount: 1, description: '', isDeleted: false } },
+        // 'absentProduct' intentionally not registered — doc does not exist in Firestore
+      ]);
+      registerCollection(MENUS_PATH, [{
+        id: 'mB',
+        data: {
+          name: 'Test Menu', displayName: null, coverImageGsl: null,
+          coverBackgroundImageGsl: null, coverVideoGsl: null, logoImageGsl: null,
+          gratuityRates: [], managedBy: null, isDeleted: false,
+          created: new Date(), updated: new Date(), version: '1.0',
+          groupDisplayOrder: ['gB'],
+          groups: {},
+          menuAssets: { gB: { assetType: 'group' } },
+          menuAssetDisplayOrder: ['gB'],
+        },
+      }]);
+
+      await rebuildMenus(BUSINESS_ID);
+
+      expect(transactionSets).toHaveLength(1);
+      const group = transactionSets[0].data.groups['gB'];
+      expect(group.productDisplayOrder).toEqual(['presentProduct']);
+      expect(group.products['absentProduct']).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
Closes #74

## Scope

**In:**
- `groupDisplayOrder` on rebuilt Menu docs now filtered to only group IDs present in `materializedGroups` — eliminates ghost IDs from deleted groups
- `productDisplayOrder` inside each materialized group now filtered against `productMap` — eliminates ghost IDs from soft-deleted and hard-deleted products
- Dead guard `if (!product || product.data.isDeleted) continue` removed from `groupProducts` loop (unreachable after the new filter)
- 3 new/extended tests covering all cases

**Out:**
- Does not clean up `menuAssets` entries for deleted groups (separate concern — owned by Remy)
- Does not add MenuGroups to `cleanupSoftDeletedDocs` in square-gateway-claude (tracked separately)
- No change to example menus (`/examples/surfaces/...`) — separate gap

## Summary

- `attemptRebuild`: `groupDisplayOrder` filtered by `id in materializedGroups` (Bug 1)
- `materializeGroups`: `productDisplayOrder` filtered by `productMap.get(pid) !== undefined && !isDeleted` (Bug 2), applied after both direct and mirror-category assignment paths
- Existing "skips deleted groups" test extended to also assert `groupDisplayOrder` is empty
- New test: soft-deleted product removed from `productDisplayOrder`
- New test: hard-deleted (absent) product removed from `productDisplayOrder`

## Test plan
- [x] `npx tsc --noEmit` — no errors
- [x] `npm test` — 684/684 passing

Generated with [Claude Code](https://claude.com/claude-code)