### PR TITLE
P-mirror-rebuild [fix]: rebuild mirror-group menus on category-membership changes (#79)

### DIFF
--- a/.archive/ISSUE_79.md
+++ b/.archive/ISSUE_79.md
@@ -1,0 +1,114 @@
+# Implementation Plan — Issue #79: Mirror-group menus not rebuilt on category-membership changes
+
+## Root cause (verified against source)
+
+`MenuRebuildService.ts` treats a mirror MenuGroup (`mirrorCategoryId` set) inconsistently:
+
+- **`materializeGroups()` (lines 144–186):** correctly uses the *category's* `productDisplayOrder` when `mirrorCategoryId` is set (lines 154–160).
+- **`resolveMenuIds()` (lines 104–136):** decides which menus to rebuild by reading each group's *own* `productDisplayOrder` (line 122). It never consults the category, and `RebuildScope` (lines 6–11) has no `changedCategoryIds`, so a product added/removed from a mirrored *category* never selects the menu. **(Part A — selection gap.)**
+- **`attemptRebuild()` prefetch (lines 255–272):** builds `allProductIds` from each group's own `productDisplayOrder` and fetches `mirrorCategoryIds` categories — but does **not** add the category's `productDisplayOrder` product IDs to `allProductIds`. So `materializeGroups()` iterating the category's order finds products missing from `productMap`, skips them (line 165), producing dangling `productDisplayOrder` entries with no `products` entry (crashes Remy ItemCard). **(Part B — prefetch gap.)**
+
+Both must ship together: Part A makes category changes trigger rebuilds; without Part B those rebuilds re-run the dangler-producing materialization.
+
+## Callers / scope wiring (verified)
+
+`rebuildMenus`, `RebuildScope`, `resolveChangedProducts` have **no in-repo callers** — re-exported via `src/domain/services/index.ts` (lines 26–29), consumed cross-repo (businesses cascade / square-gateway). Cross-repo population of `changedCategoryIds` is out of scope here; this repo (a) adds the field, (b) makes `resolveMenuIds()` honor it, (c) makes materialization correct, (d) exports `resolveChangedCategories()` for the cross-repo caller to wire.
+
+---
+
+## Part A — Selection fix
+
+### A1. Extend `RebuildScope` (lines 6–11)
+Add `changedCategoryIds?: string[];`.
+
+### A2. Make `resolveMenuIds()` mirror-aware (lines 88–142)
+1. **Resolve mirror groups' product lists from the category, not the group.** After batch-reading group docs, when `g.data.mirrorCategoryId` is set, read the group's effective product list from the mirror category's `productDisplayOrder`. Batch-read referenced categories → `categoryProductMap` (skip `isDeleted`). For each group: `groupProductMap.set(g.id, g.data.mirrorCategoryId ? (categoryProductMap.get(g.data.mirrorCategoryId) ?? []) : validProductIds(g.data.productDisplayOrder))`.
+2. **Select menus whose mirror group's `mirrorCategoryId` is in `changedCategoryIds`.** Build `groupMirrorCatMap` (groupId → mirrorCategoryId). For each menu, if any group's `mirrorCategoryId ∈ changedCategorySet`, `result.add(menu.id)`.
+3. Hoist the shared "read referenced menu-group docs + menuId→groupIds map + groupId→mirrorCategoryId map + categoryProductMap" so both branches share one batch read.
+
+### A3. Add `resolveChangedCategories()` (sibling of `resolveChangedProducts`, lines 363–407)
+```
+export async function resolveChangedCategories(businessId: string, syncTraceId: string): Promise<string[]>
+```
+Query `categoriesCollection().where('syncTraceId','==',syncTraceId).select().get()`, return `snap.docs.map(d => d.id)`. No walk-up — category membership changes are stamped directly. Export from `src/domain/services/index.ts`.
+
+---
+
+## Part B — Materialization prefetch fix (`attemptRebuild`, lines 235–322)
+
+Reorder so categories are fetched **before** products; expand `allProductIds` with each non-deleted category's `validProductIds(productDisplayOrder)` before fetching products. `Promise.all([products, categories])` becomes sequential (categories → expand → products). Result: `productMap` is a superset of every product ID `materializeGroups()` iterates → no danglers. Add a code comment referencing #79.
+
+---
+
+## Tests (`src/domain/services/__tests__/MenuRebuildService.test.ts`)
+
+Follow existing harness (`rebuildFixture.ts`, `mockFirestore`, assert on `transactionSets`). Mirror group `lWWo8L7WmEiEJuZgf3dM` → category `dKlTguVV2yNCVFJjH2sH` (9 products `mirP1..mirP9`) in menu `CcUqgkBxEnk1qYaNZ3K2`. Tests needing divergence register overrides where the group snapshot is stale.
+
+**`Part A — changedCategoryIds`:**
+- rebuilds mirror menu when its `mirrorCategoryId` in `changedCategoryIds`
+- does not rebuild menus without a group mirroring the changed category
+- no-op on empty `changedCategoryIds`
+- no-op on unknown `changedCategoryIds`
+- unions `changedCategoryIds` with `changedProductIds` (2 menus)
+- selects mirror menu when a `changedProductId` lives only in the mirror category, not the stale group snapshot
+
+**`Part B — mirror prefetch superset (no danglers)`:**
+- materializes category products absent from the stale group snapshot (written `productDisplayOrder` == 9-item category order; every entry has a `products[pid]`)
+- product added to mirrored category is materialized
+- product removed from mirrored category is dropped
+- every `productDisplayOrder` entry has a `products` entry (invariant)
+
+**`resolveChangedCategories`:**
+- returns categories matching the syncTraceId
+- returns empty when none match
+
+Regression: TC1–TC11, changedMenuGroupIds, edge-case, TOCTOU suites still pass.
+
+---
+
+## Manual verification (business `oD2Q7WkxOXBgZPM5wxMN`, "Grab and Go")
+
+1. Identify "Grab and Go" mirror MenuGroup(s), their `mirrorCategoryId`, and referencing menus.
+2. Add a product to the mirror *category*'s `productDisplayOrder`, stamp `syncTraceId`.
+3. Invoke rebuild with `changedCategoryIds` from `resolveChangedCategories(businessId, syncTraceId)` (or `rebuildMenus(businessId, { changedCategoryIds: [categoryId] })`).
+4. Read materialized menu doc: group's `productDisplayOrder` matches category order; every ID has a `products` entry (no danglers).
+5. Remove a product from the category, re-run; confirm it disappears from both.
+6. Confirm Remy "Grab and Go" renders without ItemCard crashes.
+
+---
+
+## Implementation Groups
+
+All groups edit the same `MenuRebuildService.ts` (+ index.ts, + test file), so they **serialize** — implement sequentially in one pass, not parallel subagents.
+
+### Checklist
+
+**Group 1 — Interface & selection (Part A core)**
+- [ ] Add `changedCategoryIds?: string[]` to `RebuildScope` (lines 6–11).
+- [ ] Hoist "read referenced menu-group docs + menuId→groupIds map" to run once when `changedProductIds` **or** `changedCategoryIds` present.
+- [ ] Batch-read mirror categories referenced by those groups; build `categoryProductMap` (skip deleted).
+- [ ] Build `groupProductMap` from the category's `productDisplayOrder` when group has `mirrorCategoryId`, else the group's own.
+- [ ] Build `groupMirrorCatMap` and add branch selecting menus whose group's `mirrorCategoryId ∈ changedCategoryIds`.
+- [ ] Confirm union semantics with `menuIds`, `changedProductIds`, `changedCollectionIds`, `changedMenuGroupIds` preserved.
+
+**Group 2 — Changed-category resolver & export (Part A wiring)**
+- [ ] Add exported `resolveChangedCategories(businessId, syncTraceId)`.
+- [ ] Add to barrel export in `src/domain/services/index.ts`.
+
+**Group 3 — Prefetch superset (Part B)**
+- [ ] In `attemptRebuild()`, fetch mirror categories **before** products (reorder the `Promise.all`).
+- [ ] Add each non-deleted category's `validProductIds(productDisplayOrder)` to `allProductIds` before fetching products.
+- [ ] Code comment referencing #79 explaining categories-before-products ordering.
+- [ ] Verify `materializeGroups()` now guaranteed a `productMap` superset.
+
+**Group 4 — Tests** (depends on 1–3)
+- [ ] `Part A — changedCategoryIds` block (6 cases).
+- [ ] `Part B — mirror prefetch superset` block (4 cases).
+- [ ] `resolveChangedCategories` block (2 cases).
+- [ ] Confirm existing suites still pass.
+
+**Group 5 — Version & verification** (depends on 1–4)
+- [ ] `npm run tsc` clean; `npx eslint src/` clean.
+- [ ] `npm test` green.
+- [ ] Bump `package.json` version (minor — new exported feature).
+- [ ] Manual verification against `oD2Q7WkxOXBgZPM5wxMN` "Grab and Go".

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/domain/services/MenuRebuildService.ts
+++ b/src/domain/services/MenuRebuildService.ts
@@ -86,6 +86,24 @@ function addMenusByAssetType(
   }
 }
 
+/**
+ * #79: A group's effective product list is the mirror CATEGORY's productDisplayOrder when
+ * mirrorCategoryId is set and the category exists and isn't deleted; otherwise the group's
+ * own (possibly stale) productDisplayOrder. This single rule must be used everywhere a mirror
+ * group's products are resolved (selection in resolveMenuIds and materialization in
+ * materializeGroups) so the two paths can never drift.
+ */
+function effectiveGroupProductIds(group: DocData, categoryMap: Map<string, DocData>): string[] {
+  const mirrorCatId = group.data.mirrorCategoryId;
+  if (mirrorCatId) {
+    const cat = categoryMap.get(mirrorCatId);
+    if (cat && !cat.data.isDeleted) {
+      return validProductIds(cat.data.productDisplayOrder);
+    }
+  }
+  return validProductIds(group.data.productDisplayOrder);
+}
+
 async function resolveMenuIds(
   db: FirebaseFirestore.Firestore,
   businessId: string,
@@ -136,52 +154,26 @@ async function resolveMenuIds(
     // group's own (possibly stale) productDisplayOrder. Batch-read referenced categories.
     const categoriesRef = PathResolver.categoriesCollection(businessId);
     const categoryDocs = await batchGetDocs(db, categoriesRef, [...referencedCategoryIds]);
-    const categoryProductMap = new Map<string, string[]>();
-    for (const c of categoryDocs) {
-      if (c.data.isDeleted) continue;
-      categoryProductMap.set(c.id, validProductIds(c.data.productDisplayOrder));
-    }
+    const categoryMap = new Map(categoryDocs.map((c) => [c.id, c]));
 
-    // Per-group effective product list: from the mirror category when set, else the group's own.
+    // Per-group effective product list (mirror category when set, else the group's own).
     const groupProductMap = new Map<string, string[]>();
     for (const g of groupDocs) {
-      const mirrorCatId = groupMirrorCatMap.get(g.id) ?? null;
-      groupProductMap.set(
-        g.id,
-        mirrorCatId
-          ? (categoryProductMap.get(mirrorCatId) ?? [])
-          : validProductIds(g.data.productDisplayOrder),
-      );
+      groupProductMap.set(g.id, effectiveGroupProductIds(g, categoryMap));
     }
 
-    // changedProductIds: select menus whose group's effective product list contains a changed product.
-    if (scope.changedProductIds && scope.changedProductIds.length > 0) {
-      const changedSet = new Set(scope.changedProductIds);
-      for (const menu of allMenus) {
-        const groupIds = menuGroupMap.get(menu.id) ?? [];
-        for (const gid of groupIds) {
-          const pids = groupProductMap.get(gid) ?? [];
-          if (pids.some((pid: string) => changedSet.has(pid))) {
-            result.add(menu.id);
-            break;
-          }
-        }
-      }
-    }
-
-    // #79: changedCategoryIds: select menus that have a mirror group whose mirrorCategoryId changed.
-    if (scope.changedCategoryIds && scope.changedCategoryIds.length > 0) {
-      const changedCategorySet = new Set(scope.changedCategoryIds);
-      for (const menu of allMenus) {
-        const groupIds = menuGroupMap.get(menu.id) ?? [];
-        for (const gid of groupIds) {
-          const mirrorCatId = groupMirrorCatMap.get(gid) ?? null;
-          if (mirrorCatId && changedCategorySet.has(mirrorCatId)) {
-            result.add(menu.id);
-            break;
-          }
-        }
-      }
+    // Select a menu if any of its groups either (a) contains a changed product in its effective
+    // list, or (b) #79: mirrors a category whose membership changed. Empty change sets never match.
+    const changedProductSet = new Set(scope.changedProductIds ?? []);
+    const changedCategorySet = new Set(scope.changedCategoryIds ?? []);
+    for (const menu of allMenus) {
+      const groupIds = menuGroupMap.get(menu.id) ?? [];
+      const hit = groupIds.some((gid) => {
+        const mirrorCatId = groupMirrorCatMap.get(gid) ?? null;
+        if (mirrorCatId && changedCategorySet.has(mirrorCatId)) return true;
+        return (groupProductMap.get(gid) ?? []).some((pid) => changedProductSet.has(pid));
+      });
+      if (hit) result.add(menu.id);
     }
   }
 
@@ -200,14 +192,7 @@ function materializeGroups(
   for (const group of menuGroups) {
     if (group.data.isDeleted) continue;
 
-    let productDisplayOrder = validProductIds(group.data.productDisplayOrder);
-    const mirrorCatId = group.data.mirrorCategoryId;
-    if (mirrorCatId) {
-      const cat = categoryMap.get(mirrorCatId);
-      if (cat && !cat.data.isDeleted) {
-        productDisplayOrder = validProductIds(cat.data.productDisplayOrder);
-      }
-    }
+    const productDisplayOrder = effectiveGroupProductIds(group, categoryMap);
 
     const groupProducts: Record<string, MenuProductMeta> = {};
     for (const pid of productDisplayOrder) {

--- a/src/domain/services/MenuRebuildService.ts
+++ b/src/domain/services/MenuRebuildService.ts
@@ -8,6 +8,7 @@ export interface RebuildScope {
   changedProductIds?: string[];
   changedCollectionIds?: string[];
   changedMenuGroupIds?: string[];
+  changedCategoryIds?: string[];
 }
 
 interface DocData {
@@ -101,9 +102,13 @@ async function resolveMenuIds(
     for (const id of scope.menuIds) result.add(id);
   }
 
-  if (scope.changedProductIds) {
-    const changedSet = new Set(scope.changedProductIds);
-
+  // #79: Both changedProductIds and changedCategoryIds need the same batch read of
+  // referenced MenuGroup docs (and the mirror categories they point at). Share one
+  // read so mirror-aware selection works for both branches without double Firestore traffic.
+  if (
+    (scope.changedProductIds && scope.changedProductIds.length > 0)
+    || (scope.changedCategoryIds && scope.changedCategoryIds.length > 0)
+  ) {
     // Build a map of menuId -> groupIds from menuAssets
     const menuGroupMap = new Map<string, string[]>();
     const allGroupIds = new Set<string>();
@@ -117,19 +122,64 @@ async function resolveMenuIds(
     // Batch-read all referenced MenuGroup docs
     const menuGroupsRef = PathResolver.menuGroupsCollection(businessId);
     const groupDocs = await batchGetDocs(db, menuGroupsRef, [...allGroupIds]);
-    const groupProductMap = new Map<string, string[]>();
+
+    // groupId -> mirrorCategoryId (null when not a mirror group)
+    const groupMirrorCatMap = new Map<string, string | null>();
+    const referencedCategoryIds = new Set<string>();
     for (const g of groupDocs) {
-      groupProductMap.set(g.id, validProductIds(g.data.productDisplayOrder));
+      const mirrorCatId: string | null = g.data.mirrorCategoryId ?? null;
+      groupMirrorCatMap.set(g.id, mirrorCatId);
+      if (mirrorCatId) referencedCategoryIds.add(mirrorCatId);
     }
 
-    // Check containment
-    for (const menu of allMenus) {
-      const groupIds = menuGroupMap.get(menu.id) ?? [];
-      for (const gid of groupIds) {
-        const pids = groupProductMap.get(gid) ?? [];
-        if (pids.some((pid: string) => changedSet.has(pid))) {
-          result.add(menu.id);
-          break;
+    // #79: A mirror group's effective product list lives on the mirror CATEGORY, not the
+    // group's own (possibly stale) productDisplayOrder. Batch-read referenced categories.
+    const categoriesRef = PathResolver.categoriesCollection(businessId);
+    const categoryDocs = await batchGetDocs(db, categoriesRef, [...referencedCategoryIds]);
+    const categoryProductMap = new Map<string, string[]>();
+    for (const c of categoryDocs) {
+      if (c.data.isDeleted) continue;
+      categoryProductMap.set(c.id, validProductIds(c.data.productDisplayOrder));
+    }
+
+    // Per-group effective product list: from the mirror category when set, else the group's own.
+    const groupProductMap = new Map<string, string[]>();
+    for (const g of groupDocs) {
+      const mirrorCatId = groupMirrorCatMap.get(g.id) ?? null;
+      groupProductMap.set(
+        g.id,
+        mirrorCatId
+          ? (categoryProductMap.get(mirrorCatId) ?? [])
+          : validProductIds(g.data.productDisplayOrder),
+      );
+    }
+
+    // changedProductIds: select menus whose group's effective product list contains a changed product.
+    if (scope.changedProductIds && scope.changedProductIds.length > 0) {
+      const changedSet = new Set(scope.changedProductIds);
+      for (const menu of allMenus) {
+        const groupIds = menuGroupMap.get(menu.id) ?? [];
+        for (const gid of groupIds) {
+          const pids = groupProductMap.get(gid) ?? [];
+          if (pids.some((pid: string) => changedSet.has(pid))) {
+            result.add(menu.id);
+            break;
+          }
+        }
+      }
+    }
+
+    // #79: changedCategoryIds: select menus that have a mirror group whose mirrorCategoryId changed.
+    if (scope.changedCategoryIds && scope.changedCategoryIds.length > 0) {
+      const changedCategorySet = new Set(scope.changedCategoryIds);
+      for (const menu of allMenus) {
+        const groupIds = menuGroupMap.get(menu.id) ?? [];
+        for (const gid of groupIds) {
+          const mirrorCatId = groupMirrorCatMap.get(gid) ?? null;
+          if (mirrorCatId && changedCategorySet.has(mirrorCatId)) {
+            result.add(menu.id);
+            break;
+          }
         }
       }
     }
@@ -261,15 +311,24 @@ async function attemptRebuild(
     if (group.data.mirrorCategoryId) mirrorCategoryIds.add(group.data.mirrorCategoryId);
   }
 
-  // Batch-read Products and Categories
+  // #79: Fetch mirror categories BEFORE products. materializeGroups() iterates the
+  // mirror category's productDisplayOrder (not the group's own, possibly-stale order),
+  // so the product prefetch set must include every product the category references —
+  // otherwise those IDs are missing from productMap and produce dangling
+  // productDisplayOrder entries with no matching products[pid] (crashes Remy's ItemCard).
+  // We therefore expand allProductIds with each non-deleted category's products, making
+  // productMap a guaranteed superset of everything materializeGroups() iterates.
   const productsRef = PathResolver.productsCollection(businessId);
   const categoriesRef = PathResolver.categoriesCollection(businessId);
-  const [products, categories] = await Promise.all([
-    batchGetDocs(db, productsRef, [...allProductIds]),
-    batchGetDocs(db, categoriesRef, [...mirrorCategoryIds]),
-  ]);
-  const productMap = new Map(products.map((p) => [p.id, p]));
+  const categories = await batchGetDocs(db, categoriesRef, [...mirrorCategoryIds]);
   const categoryMap = new Map(categories.map((c) => [c.id, c]));
+  for (const category of categories) {
+    if (category.data.isDeleted) continue;
+    for (const pid of validProductIds(category.data.productDisplayOrder)) allProductIds.add(pid);
+  }
+
+  const products = await batchGetDocs(db, productsRef, [...allProductIds]);
+  const productMap = new Map(products.map((p) => [p.id, p]));
 
   const materializedGroups = materializeGroups(menuGroups, productMap, categoryMap);
   const materializedCollections = materializeCollections(collections);
@@ -404,4 +463,16 @@ export async function resolveChangedProducts(businessId: string, syncTraceId: st
   }
 
   return [...changedProductIds];
+}
+
+/**
+ * #79: Resolve categories directly changed in a sync, identified by syncTraceId.
+ * Category-membership changes (products added/removed from a mirror category's
+ * productDisplayOrder) are stamped directly on the category doc — no walk-up needed.
+ * Returned IDs feed RebuildScope.changedCategoryIds so mirror-group menus get rebuilt.
+ */
+export async function resolveChangedCategories(businessId: string, syncTraceId: string): Promise<string[]> {
+  const categoriesRef = PathResolver.categoriesCollection(businessId);
+  const snap = await categoriesRef.where('syncTraceId', '==', syncTraceId).select().get();
+  return snap.docs.map((d) => d.id);
 }

--- a/src/domain/services/__tests__/MenuRebuildService.test.ts
+++ b/src/domain/services/__tests__/MenuRebuildService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { rebuildMenus, resolveChangedProducts } from '../MenuRebuildService';
+import { rebuildMenus, resolveChangedProducts, resolveChangedCategories } from '../MenuRebuildService';
 import {
   BUSINESS_ID,
   menus,
@@ -325,6 +325,190 @@ describe('MenuRebuildService', () => {
       });
       // Empty scope with no other fields => no menus selected
       expect(transactionSets).toHaveLength(0);
+    });
+  });
+
+  // ─── Part A — changedCategoryIds (#79) ────────────────────────────
+
+  describe('Part A — changedCategoryIds', () => {
+    const MIRROR_CATEGORY = 'dKlTguVV2yNCVFJjH2sH';
+    const MIRROR_MENU = 'CcUqgkBxEnk1qYaNZ3K2'; // only menu containing the mirror group
+
+    it('rebuilds the mirror menu when its mirrorCategoryId is in changedCategoryIds', async () => {
+      await rebuildMenus(BUSINESS_ID, {
+        changedCategoryIds: [MIRROR_CATEGORY],
+      });
+      expect(transactionSets).toHaveLength(1);
+      expect(transactionSets[0].ref._docId).toBe(MIRROR_MENU);
+    });
+
+    it('does not rebuild menus without a group mirroring the changed category', async () => {
+      await rebuildMenus(BUSINESS_ID, {
+        changedCategoryIds: [MIRROR_CATEGORY],
+      });
+      const menuIds = transactionSets.map((s) => s.ref._docId);
+      expect(menuIds).not.toContain('LShRjmDOXBNL7yVSD65V');
+      expect(menuIds).not.toContain('TdGQqmNhA3AjNeoyYrQn');
+      expect(menuIds).not.toContain('menu4');
+    });
+
+    it('no-ops on empty changedCategoryIds', async () => {
+      await rebuildMenus(BUSINESS_ID, {
+        changedCategoryIds: [],
+      });
+      expect(transactionSets).toHaveLength(0);
+    });
+
+    it('no-ops on unknown changedCategoryIds', async () => {
+      await rebuildMenus(BUSINESS_ID, {
+        changedCategoryIds: ['no-such-category'],
+      });
+      expect(transactionSets).toHaveLength(0);
+    });
+
+    it('unions changedCategoryIds with changedProductIds (2 menus)', async () => {
+      await rebuildMenus(BUSINESS_ID, {
+        changedCategoryIds: [MIRROR_CATEGORY], // → CcUqgkBxEnk1qYaNZ3K2
+        changedProductIds: ['hE0hUoKxy0KgplK5pfF8'], // → TdGQqmNhA3AjNeoyYrQn
+      });
+      expect(transactionSets).toHaveLength(2);
+      const menuIds = transactionSets.map((s) => s.ref._docId).sort();
+      expect(menuIds).toEqual(['CcUqgkBxEnk1qYaNZ3K2', 'TdGQqmNhA3AjNeoyYrQn'].sort());
+    });
+
+    it('selects mirror menu when a changedProductId lives only in the mirror category, not the stale group snapshot', async () => {
+      // Mirror group's own productDisplayOrder is stale (missing mirP9);
+      // category still lists mirP9. A change to mirP9 must still select the menu.
+      registerCollection(MENU_GROUPS_PATH, menuGroups.map((g) => (
+        g.id === 'lWWo8L7WmEiEJuZgf3dM'
+          ? {
+            ...g,
+            data: {
+              ...g.data,
+              // stale: missing mirP9 (lives only on the category)
+              productDisplayOrder: ['mirP1', 'mirP2', 'mirP3', 'mirP4', 'mirP5', 'mirP6', 'mirP7', 'mirP8'],
+            },
+          }
+          : g
+      )));
+
+      await rebuildMenus(BUSINESS_ID, {
+        changedProductIds: ['mirP9'],
+      });
+
+      const menuIds = transactionSets.map((s) => s.ref._docId);
+      expect(menuIds).toContain(MIRROR_MENU);
+    });
+  });
+
+  // ─── Part B — mirror prefetch superset / no danglers (#79) ────────
+
+  describe('Part B — mirror prefetch superset (no danglers)', () => {
+    const MIRROR_GROUP = 'lWWo8L7WmEiEJuZgf3dM';
+    const MIRROR_MENU = 'CcUqgkBxEnk1qYaNZ3K2';
+    const FULL_CATEGORY_ORDER = ['mirP1', 'mirP2', 'mirP3', 'mirP4', 'mirP5', 'mirP6', 'mirP7', 'mirP8', 'mirP9'];
+
+    function getMirrorGroup() {
+      const menu = transactionSets.find((s) => s.ref._docId === MIRROR_MENU)?.data;
+      return menu.groups[MIRROR_GROUP];
+    }
+
+    it('materializes category products absent from the stale group snapshot', async () => {
+      // Group snapshot is stale (only 3 products); category has all 9.
+      registerCollection(MENU_GROUPS_PATH, menuGroups.map((g) => (
+        g.id === MIRROR_GROUP
+          ? { ...g, data: { ...g.data, productDisplayOrder: ['mirP1', 'mirP2', 'mirP3'] } }
+          : g
+      )));
+
+      await rebuildMenus(BUSINESS_ID, { menuIds: [MIRROR_MENU] });
+
+      const group = getMirrorGroup();
+      expect(group.productDisplayOrder).toEqual(FULL_CATEGORY_ORDER);
+      // Every entry has a products[pid] (no danglers)
+      for (const pid of group.productDisplayOrder) {
+        expect(group.products[pid]).toBeDefined();
+      }
+      expect(Object.keys(group.products).sort()).toEqual(FULL_CATEGORY_ORDER.slice().sort());
+    });
+
+    it('materializes a product newly added to the mirrored category', async () => {
+      // Category gains mirP10; group snapshot does not know about it.
+      registerCollection(CATEGORIES_PATH, categories.map((c) => (
+        c.id === 'dKlTguVV2yNCVFJjH2sH'
+          ? { ...c, data: { ...c.data, productDisplayOrder: [...FULL_CATEGORY_ORDER, 'mirP10'] } }
+          : c
+      )));
+      registerCollection(PRODUCTS_PATH, [
+        ...products,
+        { id: 'mirP10', data: { name: 'Mirror Product 10', isActive: true, imageGsls: [], minPrice: 1000, maxPrice: 1000, variationCount: 1, description: 'Mirror Product 10 description', isDeleted: false } },
+      ]);
+
+      await rebuildMenus(BUSINESS_ID, { menuIds: [MIRROR_MENU] });
+
+      const group = getMirrorGroup();
+      expect(group.productDisplayOrder).toContain('mirP10');
+      expect(group.products.mirP10).toBeDefined();
+      expect(group.products.mirP10.minPrice).toBe(1000);
+    });
+
+    it('drops a product removed from the mirrored category', async () => {
+      // Category loses mirP9.
+      registerCollection(CATEGORIES_PATH, categories.map((c) => (
+        c.id === 'dKlTguVV2yNCVFJjH2sH'
+          ? { ...c, data: { ...c.data, productDisplayOrder: FULL_CATEGORY_ORDER.slice(0, 8) } }
+          : c
+      )));
+
+      await rebuildMenus(BUSINESS_ID, { menuIds: [MIRROR_MENU] });
+
+      const group = getMirrorGroup();
+      expect(group.productDisplayOrder).not.toContain('mirP9');
+      expect(group.products.mirP9).toBeUndefined();
+    });
+
+    it('every productDisplayOrder entry has a products entry across all rebuilt menus (invariant)', async () => {
+      // Stale group snapshot to force reliance on the category-derived prefetch.
+      registerCollection(MENU_GROUPS_PATH, menuGroups.map((g) => (
+        g.id === MIRROR_GROUP
+          ? { ...g, data: { ...g.data, productDisplayOrder: [] } }
+          : g
+      )));
+
+      await rebuildMenus(BUSINESS_ID);
+
+      for (const set of transactionSets) {
+        const groups: Record<string, any> = set.data.groups;
+        for (const group of Object.values(groups)) {
+          for (const pid of (group as any).productDisplayOrder as string[]) {
+            expect((group as any).products[pid]).toBeDefined();
+          }
+        }
+      }
+    });
+  });
+
+  // ─── resolveChangedCategories (#79) ───────────────────────────────
+
+  describe('resolveChangedCategories', () => {
+    it('returns categories matching the syncTraceId', async () => {
+      registerCollection(CATEGORIES_PATH, [
+        { id: 'cat-a', data: { syncTraceId: 'trace-1' } },
+        { id: 'cat-b', data: { syncTraceId: 'trace-1' } },
+        { id: 'cat-c', data: { syncTraceId: 'other' } },
+      ]);
+
+      const result = await resolveChangedCategories(BUSINESS_ID, 'trace-1');
+      expect(result.sort()).toEqual(['cat-a', 'cat-b']);
+    });
+
+    it('returns empty when none match', async () => {
+      registerCollection(CATEGORIES_PATH, [
+        { id: 'cat-a', data: { syncTraceId: 'other' } },
+      ]);
+
+      const result = await resolveChangedCategories(BUSINESS_ID, 'no-match');
+      expect(result).toEqual([]);
     });
   });
 

--- a/src/domain/services/index.ts
+++ b/src/domain/services/index.ts
@@ -26,6 +26,7 @@ export {
   RebuildScope,
   rebuildMenus,
   resolveChangedProducts,
+  resolveChangedCategories,
 } from './MenuRebuildService';
 
 export {


### PR DESCRIPTION
Closes #79

## Scope

**In:**
- `resolveMenuIds()` now selects a menu for rebuild when a *mirror category*'s membership changed — via a new `changedCategoryIds` field on `RebuildScope` — and resolves a mirror group's effective product list from the mirror category (not the group's stale snapshot), so a product change inside a mirrored category also selects the menu.
- `attemptRebuild()` prefetch now fetches mirror categories before products and expands the product set with each non-deleted category's `productDisplayOrder`, guaranteeing `productMap` is a superset of everything `materializeGroups()` iterates — eliminating dangling `productDisplayOrder` entries (the Remy ItemCard crash).
- New exported `resolveChangedCategories(businessId, syncTraceId)` so the cross-repo cascade caller can populate `changedCategoryIds`.
- Shared `effectiveGroupProductIds()` helper used by both selection and materialization so the mirror-resolution rule can't drift.
- Tests: category-membership selection, union with `changedProductIds`, stale-snapshot selection, prefetch-superset / no-dangler invariants, and `resolveChangedCategories`.

**Out:**
- Cross-repo wiring to *call* `resolveChangedCategories` and pass `changedCategoryIds` (businesses cascade / square-gateway) — this repo only exports the helper and honors the field.
- Legacy `onmenugroupupdate` dual-writer, `groupDisplayOrder` drift remediation, skipped-object `syncTraceId` stamping (separate issues).
- Remy `ItemCard.tsx` null guard (separate defense-in-depth companion issue).

## Summary
- Selection (Part A) and materialization (Part B) are fixed together: Part A increases rebuild frequency on category changes, and Part B keeps each rebuild dangler-free. Shipping either alone is incorrect.

## Test plan
- [x] `npm run tsc` clean, `npx eslint src/` clean (1 pre-existing warning), `npm test` green (695 tests)
- [ ] After deploy: edit a mirrored category's membership (no product-doc edit) and confirm the affected menu rebuilds with every `productDisplayOrder` entry having a matching `products` entry — observed on business `oD2Q7WkxOXBgZPM5wxMN` ("Grab and Go" mirror groups)
- [ ] Remove a product from the mirror category and confirm it disappears from the materialized menu

Generated with [Claude Code](https://claude.com/claude-code)