### PR TITLE
P19-promote-parity [feat]: single kios-master registry + prerelease/release publish lanes (#91)

### DIFF
--- a/.archive/ISSUE_91.md
+++ b/.archive/ISSUE_91.md
@@ -1,0 +1,57 @@
+# Plan — Issue #91: Library — single registry + prerelease→release promotion + promotion docs
+
+## Approach
+
+The library's CI publishes to a single Artifact Registry (`us-central1-npm.pkg.dev/kios-master/npm-packages`) on both branches, with environment isolation by **version** (prerelease vs release), never by registry. Because the two lanes run as different service accounts (declared in the build config, per "service-to-service auth must be explicit"), we use **two Cloud Build configs**:
+
+1. **`cloudbuild.yaml` (release lane, master trigger `restaurant-core-prod`)** — rewrite in place:
+   - Generate `.npmrc` pinned to `kios-master/npm-packages` (no `${PROJECT_ID}`).
+   - Install → `npm run tsc` → `npx google-artifactregistry-auth .npmrc` → `npm publish --tag latest`.
+   - No `serviceAccount` field → keeps running as legacy default SA `730024124565@cloudbuild.gserviceaccount.com` (verified writer on #90). **No prod trigger change needed.**
+
+2. **`cloudbuild-prerelease.yaml` (dev lane, NEW file)**:
+   - Same `.npmrc` pinned to `kios-master/npm-packages`.
+   - Stamp version: `BASE` from package.json → `npm version "${BASE}-dev.${SHORT_SHA}" --no-git-tag-version` (Cloud Build's built-in `$SHORT_SHA`, 7 chars).
+   - Install → `npm run tsc` → auth → `npm publish --tag next`.
+   - Declares `serviceAccount: projects/kios-master/serviceAccounts/ar-prerelease-publisher@kios-master.iam.gserviceaccount.com` and `options.logging: CLOUD_LOGGING_ONLY` (required when a user-managed SA is set).
+   - Operational consequence (documented, not in this PR): the dev-branch trigger must run **in `kios-master`** (same project as the SA) and reference `cloudbuild-prerelease.yaml`. Protected trigger on `dev` branch only; fork PRs never publish (triggers are branch-push based, not PR based).
+
+3. **`PROMOTION.md` (NEW)** — single home for promotion knowledge:
+   - The model: library owns dev→prod promotion; prerelease (`X.Y.Z-dev.<sha>`, dist-tag `next`) → graduation (`X.Y.Z`, dist-tag `latest`); one registry.
+   - Dist-tag conventions and why `latest` only moves on release.
+   - Consumer validation flow: pin exact `-dev.<sha>` in dev only while co-developing; graduate the pin to `^X.Y.Z` before prod.
+   - Immutability (AR rejects duplicate versions; per-commit unique prereleases) + armed cleanup policy (untagged `-dev.*` > 30d deleted; keep 20 recent; tagged kept).
+   - SA/security model: writer-only prerelease SA, protected triggers only, release lane is the only mover of `latest`, consumers read-only.
+   - Trigger wiring (concrete): prod trigger `restaurant-core-prod` → `cloudbuild.yaml`; dev trigger in `kios-master` → `cloudbuild-prerelease.yaml`.
+   - Rollback: git revert; registry still resolves.
+
+4. **Library `CLAUDE.md`** — replace the "Publishing" section: two lanes, single registry, version-bump rule (base version still must be bumped per master release; prereleases are unique per commit automatically), link to PROMOTION.md.
+
+5. **Root KIOS CLAUDE.md** (`/Users/jjcheng/WebstormProjects/KIOS/CLAUDE.md`) — update the CI/CD section so it no longer implies branch-based per-project publishing for this library. **Outside this git repo** — direct local edit, noted in PR body and shipping report.
+
+6. **`package.json`** — bump version 1.11.0 → 1.11.1 (repo rule: bump per publish-triggering merge; 1.11.0 may already exist in AR).
+
+## Tests / verification
+
+No runtime code changes — verification is build/lint/test integrity plus lane proofs:
+
+- **YAML validity:** parse both cloudbuild files (node js-yaml).
+- **Lane proof (dry-run, per issue test strategy):** in a scratch copy, stamp `1.11.1-dev.<sha>` and run `npm publish --dry-run --tag next` → confirm computed version + tag; and `npm publish --dry-run --tag latest` on the plain version. (No registry write.)
+- **Negative assertion (acceptance criterion):** `rg -n 'project-arya-280418|\$\{PROJECT_ID\}/npm-packages' cloudbuild*.yaml .npmrc` → zero matches (.npmrc doesn't exist in-repo; assert no checked-in .npmrc reintroduces it).
+- **Project verification suite:** `npm install`, `npm run tsc`, `npx eslint src/`, `npm test` (vitest) — must pass (pre-existing failures noted, not fixed).
+- **Docs check:** PROMOTION.md exists and covers graduation, dist-tags, consumer validation, immutability/cleanup, SA model; library CLAUDE.md links it; root CLAUDE.md CI/CD section corrected.
+- **Manual (post-merge, not in this PR):** real dev build publishes `-dev.<sha>` under `next` without moving `latest`; real master build advances `latest`. These are deployment verifications listed in the PR test plan.
+
+## Checklist
+
+- [ ] Rewrite `cloudbuild.yaml`: registry pinned to `kios-master`, publish `--tag latest`, no serviceAccount field
+- [ ] Create `cloudbuild-prerelease.yaml`: kios-master registry, `-dev.$SHORT_SHA` stamp, `--tag next`, prerelease SA + CLOUD_LOGGING_ONLY
+- [ ] Create `PROMOTION.md` covering: model, dist-tags, consumer validation flow, immutability/cleanup, SA/security, trigger wiring, rollback
+- [ ] Update library `CLAUDE.md` Publishing section (two lanes, single registry, link PROMOTION.md)
+- [ ] Update root KIOS CLAUDE.md CI/CD section (local edit outside repo)
+- [ ] Bump `package.json` version to 1.11.1
+- [ ] Verify: YAML parse, dry-run lane proofs, negative-assertion grep, tsc + eslint + vitest
+
+## Implementation Groups
+
+Single group (one sub-project, one dependency chain). Size: **Small/Medium** (6 files incl. out-of-repo doc, 7 checklist items) → single-pass implementation with full verification at the end.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,9 +19,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Tests use Vitest with `globals: true`. Test files live in `__tests__/` directories alongside source code, matching `src/**/__tests__/**/*.test.ts`.
 
-## Publishing
+## Publishing & Promotion
 
-When creating a PR against `master` or `dev`, always bump the version in `package.json` before pushing. Artifact Registry rejects duplicate versions — every merge that triggers Cloud Build must have a unique version. Use semver patch bumps for fixes, minor for features.
+This library **owns its own dev→prod promotion** — see `PROMOTION.md` for the full model. All publishes go to the **single registry** `us-central1-npm.pkg.dev/kios-master/npm-packages`; environment isolation is by version, never by registry:
+
+- **dev branch** (`cloudbuild-prerelease.yaml`): publishes a per-commit prerelease `X.Y.Z-dev.<short-sha>` under dist-tag `next`, as the publish-only SA `ar-prerelease-publisher@kios-master`. Never moves `latest`.
+- **master branch** (`cloudbuild.yaml`): graduates to the plain release `X.Y.Z` under dist-tag `latest`, as the default Cloud Build SA.
+
+When creating a PR against `master` or `dev`, always bump the base version in `package.json` before pushing. Artifact Registry rejects duplicate versions — every master merge must publish a unique `X.Y.Z`. Use semver patch bumps for fixes, minor for features. (Prerelease versions are unique per commit automatically.)
+
+Consumers validating an unreleased change pin the exact `-dev.<sha>` in their dev branch only, then graduate to `^X.Y.Z` before their own prod promotion — process in `PROMOTION.md`.
 
 ## Verification
 

--- a/PROMOTION.md
+++ b/PROMOTION.md
@@ -1,0 +1,110 @@
+# PROMOTION.md — dev → prod promotion of `@kiosinc/restaurant-core-claude`
+
+This library is the artifact with a dev↔prod duality, so **it owns its own
+dev→prod promotion**. Consuming services are thin consumers: they point at the
+right package version and receive environment as injected config. This
+document is the single home for promotion knowledge (per the P19 contract,
+kiosinc/restaurant-core-claude#89).
+
+## The model
+
+```
+dev branch     → publish PRERELEASE  X.Y.Z-dev.<short-sha>   (dist-tag: next)
+master branch  → graduate to RELEASE X.Y.Z                   (dist-tag: latest)
+
+…both to ONE registry: us-central1-npm.pkg.dev/kios-master/npm-packages
+```
+
+- **One registry** for all `@kiosinc/*` publish and consume, on both branches.
+  Environment isolation is by **version**, never by registry.
+- **Promotion = prerelease → release.** A change merged to `dev` is published
+  as a per-commit prerelease. Merging `dev` to `master` graduates it: the same
+  source publishes as the plain release version that prod consumes.
+- **Only the release lane moves `latest`.** Prereleases publish under `next`.
+  Semver range resolution (`^X.Y.Z`) excludes prereleases, so a prod consumer
+  can never accidentally resolve a `-dev.*` version.
+
+## Build lanes
+
+| Lane | Trigger branch | Build config | Version published | Dist-tag | Identity |
+|---|---|---|---|---|---|
+| Prerelease | `dev` | `cloudbuild-prerelease.yaml` | `X.Y.Z-dev.<short-sha>` | `next` | `ar-prerelease-publisher@kios-master.iam.gserviceaccount.com` |
+| Release | `master` | `cloudbuild.yaml` | `X.Y.Z` | `latest` | project default Cloud Build SA (`730024124565@cloudbuild.gserviceaccount.com`) |
+
+The prerelease lane stamps the version at build time:
+`<package.json version>-dev.<$SHORT_SHA>` via
+`npm version --no-git-tag-version`. The stamp is never committed — the
+repository always carries the plain base version.
+
+### Trigger wiring (operational, kept in sync with this table)
+
+- The **release** trigger is `restaurant-core-prod` in the `kios-master` GCP
+  project, on push to `master`, referencing `cloudbuild.yaml`. It declares no
+  per-trigger service account, so it runs as the project default Cloud Build
+  SA, which already holds `roles/artifactregistry.writer`.
+- The **prerelease** trigger must live in the `kios-master` GCP project
+  (`cloudbuild-prerelease.yaml` declares the prerelease SA, and a build can
+  only run as a service account in its own project), on push to `dev`,
+  referencing `cloudbuild-prerelease.yaml`.
+- Both triggers are **protected**: they fire only on pushes to their branch.
+  Fork PRs never publish — there is no PR-triggered publish lane.
+
+## Versioning rules
+
+- **Bump the base version in `package.json` on every PR** that will reach
+  `dev`/`master` (patch for fixes, minor for features). Artifact Registry
+  versions are immutable — a release publish of an already-existing `X.Y.Z`
+  fails the master build.
+- Prerelease versions are unique per commit automatically (the short SHA is
+  in the version), so repeated dev merges on the same base version each
+  produce a distinct, immutable artifact.
+
+## How a consumer validates an unreleased change
+
+1. **Co-develop:** in the consuming service's **dev branch only**, pin the
+   exact prerelease produced by the library's dev build:
+   ```json
+   "@kiosinc/restaurant-core-claude": "1.11.1-dev.ab12cd3"
+   ```
+   (Exact pin — never a range. `next` always points at the newest prerelease
+   if you need to discover it: `npm view @kiosinc/restaurant-core-claude dist-tags`.)
+2. **Validate** the service against the prerelease in the dev environment.
+3. **Graduate before prod:** once the library change merges to `master` (and
+   `X.Y.Z` is published under `latest`), change the service's pin back to the
+   release range (`^X.Y.Z`) **before** the service's own dev→master promotion.
+   A prod branch must never carry a `-dev.*` pin.
+
+A prerelease and the eventual release of the same source commit unpack to
+identical contents — graduation changes only the version label and dist-tag.
+
+## Immutability and cleanup
+
+- Artifact Registry rejects republishing an existing version. Nothing is ever
+  overwritten; rollback is "depend on the previous version".
+- A cleanup policy on `kios-master/npm-packages` bounds the prerelease
+  footprint: untagged versions older than 30 days are deleted; the 20 most
+  recent versions and all tagged versions are kept. Do not rely on a
+  prerelease pin for longer than 30 days — graduate it.
+
+## Security model
+
+- The prerelease lane runs as a **publish-only** service account
+  (`ar-prerelease-publisher@kios-master`): exactly one role,
+  `roles/artifactregistry.writer` on the `npm-packages` repository — no
+  delete, no admin. It runs only from the protected dev trigger, never from
+  humans or fork PRs.
+- Only the release lane (master trigger, default Cloud Build SA) publishes
+  plain versions and moves `latest`.
+- Consumers in both environments have **read-only** access
+  (`roles/artifactregistry.reader`; the dev pipeline reads cross-project via
+  its compute SA, granted in kiosinc/restaurant-core-claude#90).
+
+## Rollback
+
+- **Library change is bad:** `git revert` on the offending branch and let the
+  lane publish the next version. Consumers move their pin/range; previously
+  published versions remain available.
+- **This promotion pipeline itself:** revert the P19 PR. The dev Artifact
+  Registry (`project-arya-280418`) is not deleted until the P19 retirement
+  conditions are met (see kiosinc/restaurant-core-claude#89), so the old
+  per-project flow still resolves during any rollback window.

--- a/cloudbuild-prerelease.yaml
+++ b/cloudbuild-prerelease.yaml
@@ -1,0 +1,53 @@
+# Prerelease lane (dev branch trigger, runs in kios-master).
+#
+# Stamps a per-commit prerelease version X.Y.Z-dev.<short-sha> and publishes
+# it to the single @kiosinc registry under dist-tag `next`. `latest` is never
+# moved by this lane. See PROMOTION.md.
+#
+# Runs as the publish-only prerelease service account (declared below), so the
+# trigger that references this file must live in the kios-master project.
+# Protected trigger on the dev branch only — fork PRs never publish.
+steps:
+  # Generate .npmrc pinned to the single kios-master registry
+  - name: 'node:18'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        cat > .npmrc << EOF
+        @kiosinc:registry=https://us-central1-npm.pkg.dev/kios-master/npm-packages/
+        //us-central1-npm.pkg.dev/kios-master/npm-packages/:always-auth=true
+        EOF
+
+  # Stamp the per-commit prerelease version X.Y.Z-dev.<short-sha>
+  - name: 'node:18'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        BASE="$$(node -p "require('./package.json').version")"
+        npm version "$${BASE}-dev.${SHORT_SHA}" --no-git-tag-version
+
+  # Install dependencies
+  - name: 'node:18'
+    entrypoint: 'npm'
+    args: ['install']
+
+  # Compile TypeScript
+  - name: 'node:18'
+    entrypoint: 'npm'
+    args: ['run', 'tsc']
+
+  # Authenticate with Artifact Registry
+  - name: 'node:18'
+    entrypoint: 'npx'
+    args: ['google-artifactregistry-auth', '.npmrc']
+
+  # Publish prerelease under dist-tag `next` (never moves `latest`)
+  - name: 'node:18'
+    entrypoint: 'npm'
+    args: ['publish', '--tag', 'next']
+
+serviceAccount: 'projects/kios-master/serviceAccounts/ar-prerelease-publisher@kios-master.iam.gserviceaccount.com'
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,13 +1,22 @@
+# Release lane (master branch trigger: restaurant-core-prod).
+#
+# Publishes the plain release version X.Y.Z from package.json to the single
+# @kiosinc registry under dist-tag `latest`. This is the graduation step of
+# the prerelease -> release promotion. See PROMOTION.md.
+#
+# No `serviceAccount` field: this lane runs as the project default Cloud Build
+# service account (730024124565@cloudbuild.gserviceaccount.com), which holds
+# roles/artifactregistry.writer on kios-master.
 steps:
-  # Generate .npmrc dynamically using the current project ID
+  # Generate .npmrc pinned to the single kios-master registry
   - name: 'node:18'
     entrypoint: 'bash'
     args:
       - '-c'
       - |
         cat > .npmrc << EOF
-        @kiosinc:registry=https://us-central1-npm.pkg.dev/${PROJECT_ID}/npm-packages/
-        //us-central1-npm.pkg.dev/${PROJECT_ID}/npm-packages/:always-auth=true
+        @kiosinc:registry=https://us-central1-npm.pkg.dev/kios-master/npm-packages/
+        //us-central1-npm.pkg.dev/kios-master/npm-packages/:always-auth=true
         EOF
 
   # Install dependencies
@@ -25,7 +34,7 @@ steps:
     entrypoint: 'npx'
     args: ['google-artifactregistry-auth', '.npmrc']
 
-  # Publish to Artifact Registry
+  # Publish release X.Y.Z under dist-tag `latest` (the graduation)
   - name: 'node:18'
     entrypoint: 'npm'
-    args: ['publish']
+    args: ['publish', '--tag', 'latest']

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.10.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kiosinc/restaurant-core-claude",
-      "version": "1.10.0",
+      "version": "1.11.1",
       "license": "ISC",
       "devDependencies": {
         "@google-cloud/functions-framework": "^5.0.0",
@@ -23,6 +23,13 @@
         "typescript": "^5.8.3",
         "uuid": "^8.3.2",
         "vitest": "^4.0.18"
+      },
+      "peerDependencies": {
+        "@google-cloud/functions-framework": "^5.0.0",
+        "@google-cloud/tasks": "^6.0.0",
+        "express": "^5.0.0",
+        "firebase-admin": "^13.0.0",
+        "uuid": "^8.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Closes #91

## Scope

**In:**
- Library publishes to the single registry `us-central1-npm.pkg.dev/kios-master/npm-packages` on both branches — no `${PROJECT_ID}` host anywhere.
- Prerelease lane (`cloudbuild-prerelease.yaml`, dev trigger): stamps `X.Y.Z-dev.<short-sha>`, publishes under dist-tag `next`, runs as the publish-only SA `ar-prerelease-publisher@kios-master` (declared in the build file).
- Release lane (`cloudbuild.yaml`, master trigger `restaurant-core-prod`): publishes plain `X.Y.Z` under dist-tag `latest` as the default Cloud Build SA — no prod trigger change needed.
- Promotion knowledge documented in-repo: new `PROMOTION.md` (graduation model, dist-tag conventions, consumer prerelease validation flow, immutability/cleanup, SA/security model, trigger wiring, rollback) + library `CLAUDE.md` Publishing section rewritten.
- Version bumped 1.11.0 → 1.11.1 (unique release version for graduation; AR is immutable).

**Out:**
- GCP SA/grant/cleanup-policy creation — done and verified on #90 (infra, human-run).
- Operational trigger wiring: the dev-branch trigger must be created/moved in `kios-master` referencing `cloudbuild-prerelease.yaml` (a build can only run as an SA in its own project). Documented concretely in PROMOTION.md → Trigger wiring.
- Consumer re-pointing/pinning — kiosinc/square-gateway-claude#164 and kiosinc/webhook-receiver#29.
- Root KIOS-monorepo CLAUDE.md CI/CD correction — applied as a local edit (the monorepo root is not a git repo, so it cannot ride this PR).
- Deleting the dev AR — gated on the P19 retirement conditions (#89).

## Summary
- `cloudbuild.yaml`: registry pinned to `kios-master/npm-packages`; `npm publish --tag latest`.
- `cloudbuild-prerelease.yaml` (new): same registry; `npm version \"${BASE}-dev.${SHORT_SHA}\" --no-git-tag-version`; `npm publish --tag next`; `serviceAccount: projects/kios-master/serviceAccounts/ar-prerelease-publisher@kios-master.iam.gserviceaccount.com`; `options.logging: CLOUD_LOGGING_ONLY`.
- `PROMOTION.md` (new) + `CLAUDE.md` Publishing section.
- `package.json`/`package-lock.json`: 1.11.1.

## Test plan
- [x] Both cloudbuild files parse as valid YAML (steps/serviceAccount/logging verified programmatically).
- [x] Negative assertion: `rg -n 'project-arya-280418|$\{PROJECT_ID\}/npm-packages' cloudbuild*.yaml` → zero matches; no `.npmrc` checked in.
- [x] Dry-run lane proof: scratch stamp produced `1.11.1-dev.ab12cd3`; `npm publish --dry-run --tag next` reports that exact version.
- [x] `npm run tsc` clean; vitest 695/695 passing (76 files); ESLint identical to base (439 pre-existing problems, none introduced).
- [ ] Post-merge (dev): real dev build publishes `1.11.1-dev.<sha>` under `next`, registry host `kios-master`, `latest` untouched; second dev commit yields a distinct version.
- [ ] Post-merge (master): release build publishes `1.11.1` and advances `latest`.
- [ ] Operational: create the dev-branch trigger in `kios-master` pointing at `cloudbuild-prerelease.yaml` before the first dev publish.

Generated with [Claude Code](https://claude.com/claude-code)