### PR TITLE
Widen MenuAsset.configuration to string | Record<string, unknown>

### DIFF
--- a/src/domain/surfaces/Menu.ts
+++ b/src/domain/surfaces/Menu.ts
@@ -23,7 +23,7 @@ export interface MenuCollectionMeta {
 
 export interface MenuAsset {
   assetType: 'product' | 'group' | 'collection' | 'htmlText';
-  configuration?: Record<string, unknown>;
+  configuration?: string | Record<string, unknown>;
 }
 
 export interface MenuMeta {


### PR DESCRIPTION
## Summary

`MenuAsset.configuration` was declared as `Record<string, unknown>`, which is too narrow. Consumers assign a string preset name (e.g. mirror-group assets built in `businesses` set `configuration: 'listEntry...'`). This widens the optional field to accept both a string and a record:

```ts
configuration?: string | Record<string, unknown>;
```

## Downstream impact (within this library)

Checked all `.configuration` usages and the Menu converter:

- The only `.configuration` access on a `MenuAsset` is in `menuAssetsEqual` (`MenuRebuildService.ts`), which compares values via `JSON.stringify(...)` — handles strings, records, and `undefined` correctly. No `Object.keys()` or spread on the value anywhere.
- `Menu` uses the generic `createConverter` (`simpleConverters.ts`) with no `configuration`-specific transform; a string is a valid Firestore value, so it serializes/deserializes correctly.

No converter or guard adjustments were required.

## Verification

- `npm run tsc` — passes
- `npm test` — 695 tests pass (76 files)
- `npx eslint src/domain/surfaces/Menu.ts` — clean

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)