### PR TITLE
P29-image-resize [feat]: image pipeline contract primitives (#108)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/domain/services/FeatureFlagService.ts
+++ b/src/domain/services/FeatureFlagService.ts
@@ -6,6 +6,7 @@ export interface WriteModelFlags {
   writeLegacyOptionInventory: boolean;
   useCascadeEndpoint: boolean;
   disableImageSync: boolean;
+  isImageDownsample: boolean;
 }
 
 const DEFAULT_FLAGS: WriteModelFlags = {
@@ -14,6 +15,7 @@ const DEFAULT_FLAGS: WriteModelFlags = {
   writeLegacyOptionInventory: false,
   useCascadeEndpoint: false,
   disableImageSync: false,
+  isImageDownsample: false,
 };
 
 const CACHE_TTL_MS = 60_000;
@@ -45,6 +47,7 @@ export function createFlagService() {
         writeLegacyOptionInventory: data.writeLegacyOptionInventory ?? DEFAULT_FLAGS.writeLegacyOptionInventory,
         useCascadeEndpoint: data.useCascadeEndpoint ?? DEFAULT_FLAGS.useCascadeEndpoint,
         disableImageSync: data.disableImageSync ?? DEFAULT_FLAGS.disableImageSync,
+        isImageDownsample: data.isImageDownsample ?? DEFAULT_FLAGS.isImageDownsample,
       };
       cacheTimestamp = now;
       return cachedFlags;

--- a/src/domain/services/__tests__/FeatureFlagService.test.ts
+++ b/src/domain/services/__tests__/FeatureFlagService.test.ts
@@ -25,6 +25,7 @@ describe('FeatureFlagService', () => {
       writeLegacyOptionInventory: false,
       useCascadeEndpoint: false,
       disableImageSync: false,
+      isImageDownsample: false,
     });
   });
 
@@ -57,6 +58,26 @@ describe('FeatureFlagService', () => {
     expect(flags.enableAvailabilityDoc).toBe(true);
     expect(flags.writeLegacyOptionInventory).toBe(false);
     expect(flags.useCascadeEndpoint).toBe(false);
+  });
+
+  it('defaults isImageDownsample to false when absent in doc', async () => {
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ enableMenuRebuild: true }),
+    });
+
+    const flags = await getFlags();
+    expect(flags.isImageDownsample).toBe(false);
+  });
+
+  it('reads isImageDownsample as true when set in doc', async () => {
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ isImageDownsample: true }),
+    });
+
+    const flags = await getFlags();
+    expect(flags.isImageDownsample).toBe(true);
   });
 
   it('caches result within TTL', async () => {

--- a/src/imaging/__tests__/imageSizes.test.ts
+++ b/src/imaging/__tests__/imageSizes.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { IMAGE_SIZES, ImageSize, appendSizeToGsl } from '../imageSizes';
+
+describe('IMAGE_SIZES', () => {
+  it('is exactly [200, 400, 800, 1280]', () => {
+    expect(IMAGE_SIZES).toEqual([200, 400, 800, 1280]);
+  });
+
+  it('exposes ImageSize as a union of the supported sizes (compile-time)', () => {
+    const s200: ImageSize = 200;
+    const s400: ImageSize = 400;
+    const s800: ImageSize = 800;
+    const s1280: ImageSize = 1280;
+    expect([s200, s400, s800, s1280]).toEqual([200, 400, 800, 1280]);
+  });
+});
+
+describe('appendSizeToGsl', () => {
+  it('appends each supported size as a square suffix', () => {
+    expect(appendSizeToGsl('gs://b/foo/bar.jpg', 200)).toBe('gs://b/foo/bar_200x200.jpg');
+    expect(appendSizeToGsl('gs://b/foo/bar.jpg', 400)).toBe('gs://b/foo/bar_400x400.jpg');
+    expect(appendSizeToGsl('gs://b/foo/bar.jpg', 800)).toBe('gs://b/foo/bar_800x800.jpg');
+    expect(appendSizeToGsl('gs://b/foo/bar.jpg', 1280)).toBe('gs://b/foo/bar_1280x1280.jpg');
+  });
+
+  it('preserves the extension and its casing', () => {
+    expect(appendSizeToGsl('gs://b/foo/bar.PNG', 400)).toBe('gs://b/foo/bar_400x400.PNG');
+  });
+
+  it('treats only the final dot as the extension (multi-dot)', () => {
+    expect(appendSizeToGsl('gs://b/a.b.c.png', 800)).toBe('gs://b/a.b.c_800x800.png');
+  });
+
+  it('appends the suffix with no extension when the filename has none', () => {
+    expect(appendSizeToGsl('gs://b/foo/image', 200)).toBe('gs://b/foo/image_200x200');
+  });
+
+  it('does not treat a leading dot as an extension', () => {
+    expect(appendSizeToGsl('.gitkeep', 200)).toBe('.gitkeep_200x200');
+  });
+
+  it('does not treat a leading dot as an extension within a folder', () => {
+    expect(appendSizeToGsl('gs://b/foo/.gitkeep', 400)).toBe('gs://b/foo/.gitkeep_400x400');
+  });
+
+  it('preserves the directory path and gs scheme', () => {
+    expect(appendSizeToGsl('gs://bucket/a/b/c/photo.jpeg', 1280)).toBe(
+      'gs://bucket/a/b/c/photo_1280x1280.jpeg',
+    );
+  });
+
+  it('works on a plain relative locator without a scheme', () => {
+    expect(appendSizeToGsl('images/photo.jpg', 400)).toBe('images/photo_400x400.jpg');
+    expect(appendSizeToGsl('photo.jpg', 400)).toBe('photo_400x400.jpg');
+  });
+
+  it('throws TypeError on an empty string', () => {
+    expect(() => appendSizeToGsl('', 200)).toThrow(TypeError);
+  });
+
+  it('throws TypeError on whitespace-only input', () => {
+    expect(() => appendSizeToGsl('   ', 200)).toThrow(TypeError);
+  });
+
+  it('throws TypeError on a non-string input', () => {
+    // @ts-expect-error testing runtime guard against non-string input
+    expect(() => appendSizeToGsl(null, 200)).toThrow(TypeError);
+  });
+});

--- a/src/imaging/imageSizes.ts
+++ b/src/imaging/imageSizes.ts
@@ -1,0 +1,47 @@
+/**
+ * Image derivative-size contract for the P29 downsample pipeline.
+ *
+ * `IMAGE_SIZES` is the canonical set of square derivative widths (= heights)
+ * produced from each source image. `appendSizeToGsl` derives the sibling
+ * Google Storage Locator (gsl) for a given size, living in the same folder
+ * as the source with a `{name}_{W}x{H}.{ext}` filename.
+ */
+
+export const IMAGE_SIZES = [200, 400, 800, 1280] as const;
+
+export type ImageSize = typeof IMAGE_SIZES[number];
+
+/**
+ * Produces the same-folder sibling locator for a square derivative of `gsl`
+ * at the given `size`, e.g. `gs://b/foo/bar.jpg` + 400 → `gs://b/foo/bar_400x400.jpg`.
+ *
+ * - The scheme, bucket, and folders are preserved verbatim (split at the last `/`).
+ * - The size suffix is inserted before the extension (split at the last `.` in
+ *   the filename); multi-dot filenames keep all but the final dot as the base.
+ * - A filename with no extension gets the suffix appended with no extension.
+ * - A leading dot (e.g. `.gitkeep`) is NOT treated as an extension.
+ * - Pure function, no I/O. Does NOT require a `gs://` prefix.
+ *
+ * @throws {TypeError} if `gsl` is not a non-empty, non-whitespace-only string.
+ */
+export function appendSizeToGsl(gsl: string, size: ImageSize): string {
+  if (typeof gsl !== 'string' || gsl.trim() === '') {
+    throw new TypeError('appendSizeToGsl: gsl must be a non-empty string');
+  }
+
+  const suffix = `_${size}x${size}`;
+
+  const lastSlash = gsl.lastIndexOf('/');
+  const dir = lastSlash === -1 ? '' : gsl.slice(0, lastSlash + 1);
+  const filename = lastSlash === -1 ? gsl : gsl.slice(lastSlash + 1);
+
+  const lastDot = filename.lastIndexOf('.');
+  // A leading dot (lastDot === 0) is part of the name, not an extension.
+  if (lastDot <= 0) {
+    return `${dir}${filename}${suffix}`;
+  }
+
+  const base = filename.slice(0, lastDot);
+  const ext = filename.slice(lastDot); // includes the dot
+  return `${dir}${base}${suffix}${ext}`;
+}

--- a/src/imaging/index.ts
+++ b/src/imaging/index.ts
@@ -1,0 +1,2 @@
+export * from './images';
+export * from './imageSizes';

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,9 @@ export * as Authentication from './user/Authentication';
 export * as Claims from './user/Claims';
 export * as User from './user/User';
 
+// Imaging — image overlay interfaces & derivative-size contract
+export * as Imaging from './imaging';
+
 // Utils — unchanged
 export * as Utils from './utils';
 


### PR DESCRIPTION
Closes #108

## Scope

**In:**
- Adds the `isImageDownsample` feature flag to `WriteModelFlags` (default `false`, resolved via `?? DEFAULT`) — the generation/consumption gate consumed by the custom resizer (#40) and the apps.
- Adds the derivative-size contract: `IMAGE_SIZES = [200, 400, 800, 1280] as const` and the `ImageSize` literal-union type.
- Adds `appendSizeToGsl(gsl, size)` — the naming authority producing same-folder `{name}_{W}x{H}.{ext}` square siblings, preserving scheme/path/extension, with documented edge-case behavior (no-extension, multi-dot, leading-dot, `TypeError` on empty/whitespace input).
- Surfaces all primitives via a new `Imaging` namespace barrel (`export * as Imaging from './imaging'`), also adopting the previously-orphaned `images.ts` overlay interfaces.
- Bumps `package.json` 1.11.1 → 1.12.0 (minor; new exports).

**Out:**
- The custom Storage `onFinalize` resizer Cloud Function (#40), backfill (#42), flag default-flip rollout (#109), on-device validation (#127), and remy content-hash upload naming (#356) — those siblings *consume* these primitives.
- App-side `useSizedImageUrl` fallback / miss logging and the managed-extension retirement — owned by app repos and #40, not this library.
- No Firestore schema migration or changes to existing catalog/surface `*Gsl` fields (already structurally sound); change is purely additive.

## Summary
- New `src/imaging/imageSizes.ts` (constants, `ImageSize` type, `appendSizeToGsl`).
- New `src/imaging/index.ts` barrel + `Imaging` export in `src/index.ts`.
- `isImageDownsample` added to interface, defaults, and `getFlags()` resolution.
- New `src/imaging/__tests__/imageSizes.test.ts` (13 cases) + extended `FeatureFlagService.test.ts` (default/absent/set).

## Test plan
- [x] `npm run tsc` — clean
- [x] `npm test` — 710/710 pass (77 files), incl. new imaging + flag tests
- [x] `npx eslint` on touched files — no new errors (pre-existing repo lint debt unchanged)
- [ ] Reviewer: confirm `Imaging.appendSizeToGsl` / `Imaging.IMAGE_SIZES` / `Imaging.ImageSize` and `WriteModelFlags.isImageDownsample` resolve from the published `.d.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)