### PR TITLE
P31-kiosk-principals [feat]: add enableKioskPrincipals to writeModelFlags / FeatureFlagService (#115)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/domain/services/FeatureFlagService.ts
+++ b/src/domain/services/FeatureFlagService.ts
@@ -6,6 +6,7 @@ export interface WriteModelFlags {
   writeLegacyOptionInventory: boolean;
   useCascadeEndpoint: boolean;
   disableImageSync: boolean;
+  enableKioskPrincipals: boolean;
 }
 
 const DEFAULT_FLAGS: WriteModelFlags = {
@@ -14,6 +15,7 @@ const DEFAULT_FLAGS: WriteModelFlags = {
   writeLegacyOptionInventory: false,
   useCascadeEndpoint: false,
   disableImageSync: false,
+  enableKioskPrincipals: false,
 };
 
 const CACHE_TTL_MS = 60_000;
@@ -45,6 +47,7 @@ export function createFlagService() {
         writeLegacyOptionInventory: data.writeLegacyOptionInventory ?? DEFAULT_FLAGS.writeLegacyOptionInventory,
         useCascadeEndpoint: data.useCascadeEndpoint ?? DEFAULT_FLAGS.useCascadeEndpoint,
         disableImageSync: data.disableImageSync ?? DEFAULT_FLAGS.disableImageSync,
+        enableKioskPrincipals: data.enableKioskPrincipals ?? DEFAULT_FLAGS.enableKioskPrincipals,
       };
       cacheTimestamp = now;
       return cachedFlags;

--- a/src/domain/services/__tests__/FeatureFlagService.test.ts
+++ b/src/domain/services/__tests__/FeatureFlagService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getFlags, clearFlagCache, createFlagService, WriteModelFlags } from '../FeatureFlagService';
+import { getFlags, clearFlagCache, createFlagService } from '../FeatureFlagService';
 
 const mockDocGet = vi.fn();
 const mockDoc = vi.fn(() => ({ get: mockDocGet }));
@@ -25,6 +25,7 @@ describe('FeatureFlagService', () => {
       writeLegacyOptionInventory: false,
       useCascadeEndpoint: false,
       disableImageSync: false,
+      enableKioskPrincipals: false,
     });
   });
 
@@ -36,6 +37,7 @@ describe('FeatureFlagService', () => {
         enableAvailabilityDoc: true,
         writeLegacyOptionInventory: true,
         useCascadeEndpoint: true,
+        enableKioskPrincipals: true,
       }),
     });
 
@@ -44,6 +46,7 @@ describe('FeatureFlagService', () => {
     expect(flags.enableAvailabilityDoc).toBe(true);
     expect(flags.writeLegacyOptionInventory).toBe(true);
     expect(flags.useCascadeEndpoint).toBe(true);
+    expect(flags.enableKioskPrincipals).toBe(true);
   });
 
   it('uses defaults for missing fields in doc', async () => {
@@ -57,6 +60,7 @@ describe('FeatureFlagService', () => {
     expect(flags.enableAvailabilityDoc).toBe(true);
     expect(flags.writeLegacyOptionInventory).toBe(false);
     expect(flags.useCascadeEndpoint).toBe(false);
+    expect(flags.enableKioskPrincipals).toBe(false);
   });
 
   it('caches result within TTL', async () => {


### PR DESCRIPTION
Closes kiosinc/businesses#115

## Scope

**In:**
- Adds `enableKioskPrincipals: boolean` to the `WriteModelFlags` interface and `DEFAULT_FLAGS` (default `false`) in `FeatureFlagService`.
- Reads it from the `config/writeModelFlags` Firestore doc via `?? DEFAULT_FLAGS.enableKioskPrincipals`, mirroring `useCascadeEndpoint` exactly.
- `getFlags()` now returns `enableKioskPrincipals` — `false` when the doc or field is absent.
- Tests cover default-absent, doc-present-`true`, and field-missing-fallback cases; existing-flag assertions retained as a no-regression guard.
- Version bump `1.12.0` → `1.13.0` (additive feature) per PROMOTION.md.

**Out:**
- No server-side enforcement of the gate (consumers reading the flag — businesses/gateway/django — are separate P31 v2 issues).
- Does not touch or remove the per-device `config.kioskAuthUpgrade` flag (its removal lives elsewhere in the P31 v2 chain).
- No publish performed here — CI publishes per PROMOTION.md (`dev` → prerelease dist-tag `next`; `master` → release `latest`).
- Existing-fleet backfill is out-of-band (kiosinc/cloud-functions#47).

## Summary
- Central, server-enforceable GA toggle replacing the unsound per-device `config.kioskAuthUpgrade` flag (P31 v2 design reassessment on kiosinc/django#142).
- Purely additive: no symbol renamed/removed, no behavioral guarantee changed; `tsc` clean across the project confirms no consumer breaks.

## Test plan
- [x] Automated tests pass (703 tests, including 3 new/updated `enableKioskPrincipals` assertions)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` — 0 errors (also removed a pre-existing unused import in the test)
- [ ] On promotion: confirm `getFlags()` returns `enableKioskPrincipals: false` against a `config/writeModelFlags` doc without the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)