### PR TITLE
P31 v2: add enableAnonUserSweep flag to WriteModelFlags (gates the orphan-anon sweep)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -24,10 +24,10 @@
   },
   "homepage": "https://github.com/jjc235/restaurant-core-claude#readme",
   "peerDependencies": {
-    "firebase-admin": "^13.0.0",
-    "@google-cloud/tasks": "^6.0.0",
     "@google-cloud/functions-framework": "^5.0.0",
+    "@google-cloud/tasks": "^6.0.0",
     "express": "^5.0.0",
+    "firebase-admin": "^13.0.0",
     "uuid": "^8.0.0"
   },
   "devDependencies": {

--- a/src/domain/services/FeatureFlagService.ts
+++ b/src/domain/services/FeatureFlagService.ts
@@ -7,6 +7,7 @@ export interface WriteModelFlags {
   useCascadeEndpoint: boolean;
   disableImageSync: boolean;
   enableKioskPrincipals: boolean;
+  enableAnonUserSweep: boolean;
 }
 
 const DEFAULT_FLAGS: WriteModelFlags = {
@@ -16,6 +17,7 @@ const DEFAULT_FLAGS: WriteModelFlags = {
   useCascadeEndpoint: false,
   disableImageSync: false,
   enableKioskPrincipals: false,
+  enableAnonUserSweep: false,
 };
 
 const CACHE_TTL_MS = 60_000;
@@ -48,6 +50,7 @@ export function createFlagService() {
         useCascadeEndpoint: data.useCascadeEndpoint ?? DEFAULT_FLAGS.useCascadeEndpoint,
         disableImageSync: data.disableImageSync ?? DEFAULT_FLAGS.disableImageSync,
         enableKioskPrincipals: data.enableKioskPrincipals ?? DEFAULT_FLAGS.enableKioskPrincipals,
+        enableAnonUserSweep: data.enableAnonUserSweep ?? DEFAULT_FLAGS.enableAnonUserSweep,
       };
       cacheTimestamp = now;
       return cachedFlags;

--- a/src/domain/services/__tests__/FeatureFlagService.test.ts
+++ b/src/domain/services/__tests__/FeatureFlagService.test.ts
@@ -26,6 +26,7 @@ describe('FeatureFlagService', () => {
       useCascadeEndpoint: false,
       disableImageSync: false,
       enableKioskPrincipals: false,
+      enableAnonUserSweep: false,
     });
   });
 
@@ -38,6 +39,7 @@ describe('FeatureFlagService', () => {
         writeLegacyOptionInventory: true,
         useCascadeEndpoint: true,
         enableKioskPrincipals: true,
+        enableAnonUserSweep: true,
       }),
     });
 
@@ -47,6 +49,7 @@ describe('FeatureFlagService', () => {
     expect(flags.writeLegacyOptionInventory).toBe(true);
     expect(flags.useCascadeEndpoint).toBe(true);
     expect(flags.enableKioskPrincipals).toBe(true);
+    expect(flags.enableAnonUserSweep).toBe(true);
   });
 
   it('uses defaults for missing fields in doc', async () => {
@@ -61,6 +64,7 @@ describe('FeatureFlagService', () => {
     expect(flags.writeLegacyOptionInventory).toBe(false);
     expect(flags.useCascadeEndpoint).toBe(false);
     expect(flags.enableKioskPrincipals).toBe(false);
+    expect(flags.enableAnonUserSweep).toBe(false);
   });
 
   it('caches result within TTL', async () => {


### PR DESCRIPTION
Closes kiosinc/businesses#118

Adds `enableAnonUserSweep: boolean` (default `false`) to `WriteModelFlags` / `FeatureFlagService` (interface + DEFAULT_FLAGS + `config/writeModelFlags` doc-read mapping), mirroring `enableKioskPrincipals`. Version 1.13.0 → 1.14.0.

Gates the destructive orphaned-anonymous-user sweep (kiosinc/cloud-functions#47, re-homing to CloudFunctions) — ships dormant, flip the flag in `config/writeModelFlags` to enable. The sweep (CloudFunctions) will check `getFlags().enableAnonUserSweep` before deleting anything.

Verified: tsc clean, FeatureFlagService tests 7/7 (default-absent, doc-true, fallback for the new flag). Part of P31 v2 — kiosinc/django#142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)