### PR TITLE
P31-kiosk-principals [feat]: add kioskClaimsReconcilerCanonical flag to WriteModelFlags (#123)

### DIFF
--- a/src/domain/services/FeatureFlagService.ts
+++ b/src/domain/services/FeatureFlagService.ts
@@ -8,6 +8,7 @@ export interface WriteModelFlags {
   disableImageSync: boolean;
   enableKioskPrincipals: boolean;
   enableAnonUserSweep: boolean;
+  kioskClaimsReconcilerCanonical: boolean;
 }
 
 const DEFAULT_FLAGS: WriteModelFlags = {
@@ -18,6 +19,7 @@ const DEFAULT_FLAGS: WriteModelFlags = {
   disableImageSync: false,
   enableKioskPrincipals: false,
   enableAnonUserSweep: false,
+  kioskClaimsReconcilerCanonical: false,
 };
 
 const CACHE_TTL_MS = 60_000;
@@ -51,6 +53,8 @@ export function createFlagService() {
         disableImageSync: data.disableImageSync ?? DEFAULT_FLAGS.disableImageSync,
         enableKioskPrincipals: data.enableKioskPrincipals ?? DEFAULT_FLAGS.enableKioskPrincipals,
         enableAnonUserSweep: data.enableAnonUserSweep ?? DEFAULT_FLAGS.enableAnonUserSweep,
+        kioskClaimsReconcilerCanonical:
+          data.kioskClaimsReconcilerCanonical ?? DEFAULT_FLAGS.kioskClaimsReconcilerCanonical,
       };
       cacheTimestamp = now;
       return cachedFlags;

--- a/src/domain/services/__tests__/FeatureFlagService.test.ts
+++ b/src/domain/services/__tests__/FeatureFlagService.test.ts
@@ -27,6 +27,7 @@ describe('FeatureFlagService', () => {
       disableImageSync: false,
       enableKioskPrincipals: false,
       enableAnonUserSweep: false,
+      kioskClaimsReconcilerCanonical: false,
     });
   });
 
@@ -40,6 +41,7 @@ describe('FeatureFlagService', () => {
         useCascadeEndpoint: true,
         enableKioskPrincipals: true,
         enableAnonUserSweep: true,
+        kioskClaimsReconcilerCanonical: true,
       }),
     });
 
@@ -50,6 +52,7 @@ describe('FeatureFlagService', () => {
     expect(flags.useCascadeEndpoint).toBe(true);
     expect(flags.enableKioskPrincipals).toBe(true);
     expect(flags.enableAnonUserSweep).toBe(true);
+    expect(flags.kioskClaimsReconcilerCanonical).toBe(true);
   });
 
   it('uses defaults for missing fields in doc', async () => {
@@ -65,6 +68,7 @@ describe('FeatureFlagService', () => {
     expect(flags.useCascadeEndpoint).toBe(false);
     expect(flags.enableKioskPrincipals).toBe(false);
     expect(flags.enableAnonUserSweep).toBe(false);
+    expect(flags.kioskClaimsReconcilerCanonical).toBe(false);
   });
 
   it('caches result within TTL', async () => {


### PR DESCRIPTION
Closes #123

## Scope

**In:**
- Adds `kioskClaimsReconcilerCanonical: boolean` to the `WriteModelFlags` interface in `FeatureFlagService`.
- Defaults to `false` in `DEFAULT_FLAGS`.
- Maps it in `getFlags()` from the Firestore `config/writeModelFlags` doc with a `?? DEFAULT` fallback.
- Parity unit tests: default-when-doc-absent, read-from-doc (true), missing-field-fallback (false).

**Out:**
- The in-process consumer that *reads* this flag to gate kiosk claim re-application lives in cloud-functions-businesses (#27) — not in this library.
- No `package.json` version bump: `project/31` defers the single version bump to the rollup PR (matching sibling flag PRs #116/#118 on this integration branch).

## Summary
- Mirrors the existing `enableKioskPrincipals` / `enableAnonUserSweep` flags exactly — declared in the interface, `DEFAULT_FLAGS`, and the `getFlags()` read mapping.
- Purely additive and backward-compatible: existing Firestore docs without the field fall back to the `false` default.

## Test plan
- [x] Type-check (`npx tsc --noEmit`) — clean
- [x] Lint (`npx eslint`) — 0 errors (2 pre-existing warnings on untouched lines)
- [x] Tests (`npm test`) — 703/703 pass, including the 3 new parity assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)