### PR TITLE
Revert: remove kioskClaimsReconcilerCanonical flag (A3 backed out — not needed for P31)

### DIFF
--- a/src/domain/services/FeatureFlagService.ts
+++ b/src/domain/services/FeatureFlagService.ts
@@ -8,7 +8,6 @@ export interface WriteModelFlags {
   disableImageSync: boolean;
   enableKioskPrincipals: boolean;
   enableAnonUserSweep: boolean;
-  kioskClaimsReconcilerCanonical: boolean;
 }
 
 const DEFAULT_FLAGS: WriteModelFlags = {
@@ -19,7 +18,6 @@ const DEFAULT_FLAGS: WriteModelFlags = {
   disableImageSync: false,
   enableKioskPrincipals: false,
   enableAnonUserSweep: false,
-  kioskClaimsReconcilerCanonical: false,
 };
 
 const CACHE_TTL_MS = 60_000;
@@ -53,8 +51,6 @@ export function createFlagService() {
         disableImageSync: data.disableImageSync ?? DEFAULT_FLAGS.disableImageSync,
         enableKioskPrincipals: data.enableKioskPrincipals ?? DEFAULT_FLAGS.enableKioskPrincipals,
         enableAnonUserSweep: data.enableAnonUserSweep ?? DEFAULT_FLAGS.enableAnonUserSweep,
-        kioskClaimsReconcilerCanonical:
-          data.kioskClaimsReconcilerCanonical ?? DEFAULT_FLAGS.kioskClaimsReconcilerCanonical,
       };
       cacheTimestamp = now;
       return cachedFlags;

--- a/src/domain/services/__tests__/FeatureFlagService.test.ts
+++ b/src/domain/services/__tests__/FeatureFlagService.test.ts
@@ -27,7 +27,6 @@ describe('FeatureFlagService', () => {
       disableImageSync: false,
       enableKioskPrincipals: false,
       enableAnonUserSweep: false,
-      kioskClaimsReconcilerCanonical: false,
     });
   });
 
@@ -41,7 +40,6 @@ describe('FeatureFlagService', () => {
         useCascadeEndpoint: true,
         enableKioskPrincipals: true,
         enableAnonUserSweep: true,
-        kioskClaimsReconcilerCanonical: true,
       }),
     });
 
@@ -52,7 +50,6 @@ describe('FeatureFlagService', () => {
     expect(flags.useCascadeEndpoint).toBe(true);
     expect(flags.enableKioskPrincipals).toBe(true);
     expect(flags.enableAnonUserSweep).toBe(true);
-    expect(flags.kioskClaimsReconcilerCanonical).toBe(true);
   });
 
   it('uses defaults for missing fields in doc', async () => {
@@ -68,7 +65,6 @@ describe('FeatureFlagService', () => {
     expect(flags.useCascadeEndpoint).toBe(false);
     expect(flags.enableKioskPrincipals).toBe(false);
     expect(flags.enableAnonUserSweep).toBe(false);
-    expect(flags.kioskClaimsReconcilerCanonical).toBe(false);
   });
 
   it('caches result within TTL', async () => {


### PR DESCRIPTION
Removes the `kioskClaimsReconcilerCanonical` WriteModelFlags field added in #123/#125. Backed out alongside businesses#290: django/P31 kiosks change location via direct `config.locationId` writes, so the cfb reconciler is already the sole claim-re-apply owner — the flag gated a path (kioskSetLocation) that P31 kiosks never use, and legacy kiosks can never be scoped. Keeps WriteModelFlags free of an unused field before the #117 prod publish.

Refs #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)