### PR TITLE
P31-kiosk-principals [refactor]: shared buildKioskClaim factory (#124)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/user/User.ts
+++ b/src/user/User.ts
@@ -35,3 +35,39 @@ export interface KioskUser {
 
 /** Authenticated principal attached to `req.user`. */
 export type User = BusinessUser | KioskUser;
+
+/**
+ * The top-level Firebase custom-claim object written for a kiosk principal via
+ * `setCustomUserClaims`. It is the *encode* counterpart of {@link KioskUser}:
+ * the auth middleware decodes these same top-level fields back into a
+ * `KioskUser`. `claimsVersion` is the refresh signal mirrored on the device doc.
+ */
+export interface KioskClaim {
+  role: 'kiosk';
+  businessId: string;
+  locationId: string;
+  claimsVersion?: number;
+}
+
+/**
+ * Single source of truth for the kiosk custom-claim shape. Both the businesses
+ * service and the firestore-functions (cfb) kiosk trigger construct the claim
+ * through this factory so the literal can never drift again (the missing
+ * `claimsVersion` seam, cfb#22, was a direct symptom of the duplicated literal).
+ *
+ * Pure — it never touches Firebase Admin. Callers pass the result to
+ * `getAuth().setCustomUserClaims(uid, buildKioskClaim(...))`. The `claimsVersion`
+ * key is always present (possibly `undefined`); Firebase's JSON serialization
+ * drops an `undefined` value, so omitting vs. passing `undefined` is identical
+ * on the wire — matching the existing call-site behavior exactly.
+ */
+export function buildKioskClaim(params: {
+  businessId: string;
+  locationId: string;
+  claimsVersion?: number;
+}): KioskClaim {
+  const { businessId, locationId, claimsVersion } = params;
+  return {
+    role: 'kiosk', businessId, locationId, claimsVersion,
+  };
+}

--- a/src/user/__tests__/KioskClaim.test.ts
+++ b/src/user/__tests__/KioskClaim.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { buildKioskClaim, type KioskClaim } from '../User';
+
+describe('buildKioskClaim', () => {
+  it('happy path — with claimsVersion returns the full kiosk claim literal', () => {
+    const claim = buildKioskClaim({
+      businessId: 'biz-1',
+      locationId: 'loc-1',
+      claimsVersion: 3,
+    });
+
+    expect(claim).toEqual({
+      role: 'kiosk',
+      businessId: 'biz-1',
+      locationId: 'loc-1',
+      claimsVersion: 3,
+    });
+  });
+
+  it('omitted claimsVersion — key is present and undefined (matches the businesses literal exactly)', () => {
+    const claim = buildKioskClaim({ businessId: 'biz-1', locationId: 'loc-1' });
+
+    expect(claim.role).toBe('kiosk');
+    expect(claim.businessId).toBe('biz-1');
+    expect(claim.locationId).toBe('loc-1');
+    expect(claim.claimsVersion).toBeUndefined();
+    // The key must exist on the object so the produced claim is byte-identical
+    // to the current `{ role, businessId, locationId, claimsVersion }` literal.
+    expect('claimsVersion' in claim).toBe(true);
+  });
+
+  it('role is always the literal "kiosk" regardless of inputs', () => {
+    expect(buildKioskClaim({ businessId: '', locationId: '' }).role).toBe('kiosk');
+  });
+
+  it('boundary — empty-string ids pass through unchanged (permissive, mirrors auth-middleware attach)', () => {
+    const claim = buildKioskClaim({ businessId: '', locationId: '', claimsVersion: 7 });
+
+    expect(claim).toEqual({
+      role: 'kiosk',
+      businessId: '',
+      locationId: '',
+      claimsVersion: 7,
+    });
+  });
+
+  it('boundary — claimsVersion 0 is preserved, not coerced or dropped', () => {
+    const claim = buildKioskClaim({ businessId: 'biz-1', locationId: 'loc-1', claimsVersion: 0 });
+
+    expect(claim.claimsVersion).toBe(0);
+  });
+
+  it('result is assignable to a Firebase custom-claims object (Record<string, unknown>)', () => {
+    const claim: KioskClaim = buildKioskClaim({ businessId: 'biz-1', locationId: 'loc-1' });
+    // Compile-time check: the claim is a valid setCustomUserClaims argument.
+    const customClaims: Record<string, unknown> = claim;
+
+    expect(customClaims.role).toBe('kiosk');
+  });
+});


### PR DESCRIPTION
Closes #124

## Scope

**In:**
- New pure factory `User.buildKioskClaim({ businessId, locationId, claimsVersion })` + `KioskClaim` type in `src/user/User.ts` (single source of truth for the kiosk custom-claim shape, co-located with the existing `KioskUser` decode type).
- Unit tests (`src/user/__tests__/KioskClaim.test.ts`): happy path, omitted `claimsVersion` (key present + undefined → byte-identical to the businesses literal), `role` always `'kiosk'`, empty-id boundary, `claimsVersion: 0` boundary, assignability to a custom-claims object.
- Version bump 1.14.0 → 1.15.0 (additive feature, per PROMOTION.md).

**Out:**
- Migrating the `businesses` (`kioskClaimsService.ts`) and `cloud-functions-businesses` (`kiosk/utils.ts`) call sites to consume the factory — separate per-repo PRs (the issue's "businesses + cfb both consume it" criterion).
- Adding `@kiosinc/restaurant-core-claude` to cfb's dependencies — cfb currently has no rcc dependency, so its adoption is sequenced behind that (anticipated by the issue: "the helper still lands in rcc").
- No rcc behavior change: rcc has zero kiosk-claim call sites, so this is purely additive.

## Summary
- Consolidates the duplicated claim literal `{ role: 'kiosk', businessId, locationId, claimsVersion }` that drifted across two repos (cfb#22 dropped `claimsVersion`) into one rcc-owned encode factory paired with the existing `KioskUser` decode type.
- `claimsVersion` key is always present (possibly `undefined`); Firebase JSON-serialization drops `undefined`, so consuming the factory is a no-op on the wire vs. today's literal.

## Test plan
- [x] Automated tests pass (709 tests, incl. 6 new `buildKioskClaim` cases)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)