### PR TITLE
P32-presence-rtdb [feat]: add writeLegacyFirestorePresence flag to WriteModelFlags (#120)

### DIFF
--- a/src/domain/services/FeatureFlagService.ts
+++ b/src/domain/services/FeatureFlagService.ts
@@ -8,6 +8,7 @@ export interface WriteModelFlags {
   disableImageSync: boolean;
   enableKioskPrincipals: boolean;
   enableAnonUserSweep: boolean;
+  writeLegacyFirestorePresence: boolean;
 }
 
 const DEFAULT_FLAGS: WriteModelFlags = {
@@ -18,6 +19,7 @@ const DEFAULT_FLAGS: WriteModelFlags = {
   disableImageSync: false,
   enableKioskPrincipals: false,
   enableAnonUserSweep: false,
+  writeLegacyFirestorePresence: true,
 };
 
 const CACHE_TTL_MS = 60_000;
@@ -51,6 +53,7 @@ export function createFlagService() {
         disableImageSync: data.disableImageSync ?? DEFAULT_FLAGS.disableImageSync,
         enableKioskPrincipals: data.enableKioskPrincipals ?? DEFAULT_FLAGS.enableKioskPrincipals,
         enableAnonUserSweep: data.enableAnonUserSweep ?? DEFAULT_FLAGS.enableAnonUserSweep,
+        writeLegacyFirestorePresence: data.writeLegacyFirestorePresence ?? DEFAULT_FLAGS.writeLegacyFirestorePresence,
       };
       cacheTimestamp = now;
       return cachedFlags;

--- a/src/domain/services/__tests__/FeatureFlagService.test.ts
+++ b/src/domain/services/__tests__/FeatureFlagService.test.ts
@@ -27,6 +27,7 @@ describe('FeatureFlagService', () => {
       disableImageSync: false,
       enableKioskPrincipals: false,
       enableAnonUserSweep: false,
+      writeLegacyFirestorePresence: true,
     });
   });
 
@@ -40,6 +41,7 @@ describe('FeatureFlagService', () => {
         useCascadeEndpoint: true,
         enableKioskPrincipals: true,
         enableAnonUserSweep: true,
+        writeLegacyFirestorePresence: false,
       }),
     });
 
@@ -50,6 +52,7 @@ describe('FeatureFlagService', () => {
     expect(flags.useCascadeEndpoint).toBe(true);
     expect(flags.enableKioskPrincipals).toBe(true);
     expect(flags.enableAnonUserSweep).toBe(true);
+    expect(flags.writeLegacyFirestorePresence).toBe(false);
   });
 
   it('uses defaults for missing fields in doc', async () => {
@@ -65,6 +68,7 @@ describe('FeatureFlagService', () => {
     expect(flags.useCascadeEndpoint).toBe(false);
     expect(flags.enableKioskPrincipals).toBe(false);
     expect(flags.enableAnonUserSweep).toBe(false);
+    expect(flags.writeLegacyFirestorePresence).toBe(true);
   });
 
   it('caches result within TTL', async () => {


### PR DESCRIPTION
Closes #120

## Scope

**In:**
- Adds `writeLegacyFirestorePresence: boolean` to the `WriteModelFlags` interface in `FeatureFlagService`, defaulting to `true` (legacy Firestore presence is the primary write during the P32 dual-write window; flip to `false` at cutover).
- Wires the flag into `DEFAULT_FLAGS` and the `getFlags()` Firestore doc-merge (`/config/writeModelFlags`) using the existing nullish-coalescing convention.
- Unit tests: flag present in defaults, read from doc (explicit `false` honored), and defaults to `true` when absent from an existing doc.

**Out:**
- No RTDB write behavior, no `device_presence_scanned` metric, no `/presence/{udid}` node, no 30s/90s tuning — those live in the consuming services (Django, cloud-functions) and are separate P32 issues.
- No consumer wiring: this only adds the flag to the shared library; services read it via `getFlags()`.

## Summary
- Mirrors the established 3-part flag pattern (interface field + `DEFAULT_FLAGS` entry + `getFlags()` mapping) exactly.
- Default `true` follows the `enableMenuRebuild`/`enableAvailabilityDoc` legacy-primary convention.

## Test plan
- [x] `npx tsc -p tsconfig.json` passes (exit 0)
- [x] `npm test` passes (78 files / 709 tests)
- [ ] Prerelease published by CI on merge to `dev` (via the P32 rollup) per PROMOTION.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)