### PR TITLE
Project 32: restaurant-core-claude rollup (P32 presence→RTDB)

### DIFF
--- a/src/domain/services/FeatureFlagService.ts
+++ b/src/domain/services/FeatureFlagService.ts
@@ -8,6 +8,7 @@ export interface WriteModelFlags {
   disableImageSync: boolean;
   enableKioskPrincipals: boolean;
   enableAnonUserSweep: boolean;
+  writeLegacyFirestorePresence: boolean;
 }
 
 const DEFAULT_FLAGS: WriteModelFlags = {
@@ -18,6 +19,7 @@ const DEFAULT_FLAGS: WriteModelFlags = {
   disableImageSync: false,
   enableKioskPrincipals: false,
   enableAnonUserSweep: false,
+  writeLegacyFirestorePresence: true,
 };
 
 const CACHE_TTL_MS = 60_000;
@@ -51,6 +53,7 @@ export function createFlagService() {
         disableImageSync: data.disableImageSync ?? DEFAULT_FLAGS.disableImageSync,
         enableKioskPrincipals: data.enableKioskPrincipals ?? DEFAULT_FLAGS.enableKioskPrincipals,
         enableAnonUserSweep: data.enableAnonUserSweep ?? DEFAULT_FLAGS.enableAnonUserSweep,
+        writeLegacyFirestorePresence: data.writeLegacyFirestorePresence ?? DEFAULT_FLAGS.writeLegacyFirestorePresence,
       };
       cacheTimestamp = now;
       return cachedFlags;

--- a/src/domain/services/__tests__/FeatureFlagService.test.ts
+++ b/src/domain/services/__tests__/FeatureFlagService.test.ts
@@ -27,6 +27,7 @@ describe('FeatureFlagService', () => {
       disableImageSync: false,
       enableKioskPrincipals: false,
       enableAnonUserSweep: false,
+      writeLegacyFirestorePresence: true,
     });
   });
 
@@ -40,6 +41,7 @@ describe('FeatureFlagService', () => {
         useCascadeEndpoint: true,
         enableKioskPrincipals: true,
         enableAnonUserSweep: true,
+        writeLegacyFirestorePresence: false,
       }),
     });
 
@@ -50,6 +52,7 @@ describe('FeatureFlagService', () => {
     expect(flags.useCascadeEndpoint).toBe(true);
     expect(flags.enableKioskPrincipals).toBe(true);
     expect(flags.enableAnonUserSweep).toBe(true);
+    expect(flags.writeLegacyFirestorePresence).toBe(false);
   });
 
   it('uses defaults for missing fields in doc', async () => {
@@ -65,6 +68,7 @@ describe('FeatureFlagService', () => {
     expect(flags.useCascadeEndpoint).toBe(false);
     expect(flags.enableKioskPrincipals).toBe(false);
     expect(flags.enableAnonUserSweep).toBe(false);
+    expect(flags.writeLegacyFirestorePresence).toBe(true);
   });
 
   it('caches result within TTL', async () => {


### PR DESCRIPTION
Closes #120

writeLegacyFirestorePresence flag added to WriteModelFlags (default true). Wave PR #128. Prerelease publishes on merge to dev per PROMOTION.md.

Part of P32 presence→RTDB migration. Epic: kiosinc/businesses#278. This rollup merges the project/32 integration branch into `dev`; the `Closes` reference(s) above fire on merge.