### PR TITLE
chore: bump version to 1.16.0 (unblock release publish of #137 content)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.11.1",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kiosinc/restaurant-core-claude",
-      "version": "1.11.1",
+      "version": "1.16.0",
       "license": "ISC",
       "devDependencies": {
         "@google-cloud/functions-framework": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
The #137 merge's release build failed E400: 1.15.0 already exists in Artifact Registry (published by the June P29 master promotion #122), and AR rejects duplicate versions. #137 missed this repo's bump-before-merge rule.

Merging publishes **1.16.0** (latest): P32 `writeLegacyFirestorePresence`, P31 `buildKioskClaim`, MenuAsset.configuration widening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)