### PR TITLE
AvailabilityService [feat]: make OptionAvailability count/state/timestamp optional (#141)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kiosinc/restaurant-core-claude",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "license": "ISC",
       "devDependencies": {
         "@google-cloud/functions-framework": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/domain/services/AvailabilityService.ts
+++ b/src/domain/services/AvailabilityService.ts
@@ -8,9 +8,9 @@ export interface ProductAvailability {
 
 export interface OptionAvailability {
   isAvailable: boolean;
-  count: number;
-  state: 'inStock' | 'soldOut';
-  timestamp: string;
+  count?: number;
+  state?: 'inStock' | 'soldOut';
+  timestamp?: string;
 }
 
 export interface AvailabilityDoc {

--- a/src/domain/services/__tests__/AvailabilityService.test.ts
+++ b/src/domain/services/__tests__/AvailabilityService.test.ts
@@ -125,6 +125,66 @@ describe('AvailabilityService', () => {
     });
   });
 
+  // #141: count/state/timestamp are optional — catalog sync writes partial
+  // entries ({isAvailable} for tracked, {isAvailable, state} for untracked);
+  // only the inventory webhook writes all four fields.
+  describe('partial OptionAvailability writes (#141)', () => {
+    it('accepts and writes an isAvailable-only option entry', async () => {
+      await setOptionAvailability('biz-1', 'loc-1', 'opt-1', { isAvailable: true });
+
+      expect(mockDocSet).toHaveBeenCalledWith(
+        { options: { 'opt-1': { isAvailable: true } } },
+        { merge: true },
+      );
+    });
+
+    it('accepts and writes an {isAvailable, state} option entry (untracked location)', async () => {
+      await setOptionAvailability('biz-1', 'loc-1', 'opt-1', { isAvailable: false, state: 'soldOut' });
+
+      expect(mockDocSet).toHaveBeenCalledWith(
+        { options: { 'opt-1': { isAvailable: false, state: 'soldOut' } } },
+        { merge: true },
+      );
+    });
+
+    it('accepts partial option entries through updateAvailability', async () => {
+      await updateAvailability('biz-1', 'loc-1', {
+        options: { 'opt-1': { isAvailable: true } },
+      });
+
+      expect(mockDocSet).toHaveBeenCalledWith(
+        { options: { 'opt-1': { isAvailable: true } } },
+        { merge: true },
+      );
+    });
+
+    it('reads back a partial option entry without the optional fields', async () => {
+      mockDocGet.mockResolvedValue({
+        exists: true,
+        data: () => ({
+          options: { 'opt-1': { isAvailable: true } },
+        }),
+      });
+
+      const result = await getAvailability('biz-1', 'loc-1');
+      expect(result!.options['opt-1'].isAvailable).toBe(true);
+      expect(result!.options['opt-1'].count).toBeUndefined();
+      expect(result!.options['opt-1'].state).toBeUndefined();
+      expect(result!.options['opt-1'].timestamp).toBeUndefined();
+    });
+
+    it('getOptionTimestamp returns undefined for a partial entry without timestamp', async () => {
+      mockDocGet.mockResolvedValue({
+        exists: true,
+        data: () => ({
+          options: { 'opt-1': { isAvailable: true } },
+        }),
+      });
+      const result = await getOptionTimestamp('biz-1', 'loc-1', 'opt-1');
+      expect(result).toBeUndefined();
+    });
+  });
+
   describe('setProductAvailabilityBatch', () => {
     it('merge-sets multiple products under products', async () => {
       await setProductAvailabilityBatch('biz-1', 'loc-1', {


### PR DESCRIPTION
Closes #141

## Scope

**In:**
- Widen `OptionAvailability` in `src/domain/services/AvailabilityService.ts` so `count`/`state`/`timestamp` are optional (matches `ProductAvailability`'s existing optionality pattern)
- Audit of every library-internal reader of the now-optional fields for undefined-safety
- Version/promotion setup for release as `1.17.0`

**Out:**
- `kios-commons-types` companion widening (`types/availabilityTypes.ts`) — non-blocking, django already reads null-safely; see the issue's "Related" section.

## Summary

- **Interface widening**: `OptionAvailability` is now `{ isAvailable: boolean; count?: number; state?: 'inStock' | 'soldOut'; timestamp?: string }`. The stored doc shape is genuinely partial after kiosinc/square-gateway-claude#243: catalog sync merge-writes `{isAvailable}` for tracked variations and `{isAvailable, state}` for untracked ones; only the inventory webhook pipeline writes all four fields (stamping Square `calculated_at`).
- **Signatures unchanged**: `setOptionAvailability` / `updateAvailability` are untouched — the Firestore nested merge-set already writes only the keys provided.
- **Internal reader audit** (whole `src/` tree greped for `.count` / `.state` / `.timestamp` reads on `OptionAvailability`):
  - `getOptionTimestamp` (`AvailabilityService.ts`) — the **only** internal reader of an optional field; already undefined-safe (`doc?.options?.[optionId]?.timestamp` with `ts ? new Date(ts) : undefined`). No change needed.
  - No other reader exists: `AvailabilityDoc.options` is consumed nowhere else in the library; `index.ts` only re-exports the types/functions. The `inStock`/`soldOut` hits in `InventoryCount.ts` / `inventoryCountHelper.ts` are the separate legacy embedded-inventory type, not `OptionAvailability`.
- **Version/promotion setup** (per `PROMOTION.md`): base version bumped `1.16.0` → `1.17.0` (minor — feature) in `package.json` + `package-lock.json` in this PR, as PROMOTION.md requires ("bump the base version in package.json on every PR"). CI handles the rest: merge to `dev` publishes prerelease `1.17.0-dev.<short-sha>` (dist-tag `next`); the subsequent `dev` → `master` merge graduates it to `1.17.0` (dist-tag `latest`).
- **Tests**: new `partial OptionAvailability writes (#141)` block in `src/domain/services/__tests__/AvailabilityService.test.ts` exercising an `{isAvailable}`-only write, an `{isAvailable, state}` (untracked-location) write, a partial write via `updateAvailability`, partial read-back through `getAvailability`, and `getOptionTimestamp` on a timestamp-less entry.

## Test plan

- [x] `npm run tsc` — clean compile
- [x] `npm test` — 79 files / 729 tests, all pass (including the new partial-write tests)
- [x] `npx eslint` on changed files — 0 errors (9 pre-existing-style non-null-assertion warnings, same pattern already present in these files)
- [ ] After dev merge: confirm `1.17.0-dev.<sha>` appears under dist-tag `next` (`npm view @kiosinc/restaurant-core-claude dist-tags`)
- [ ] After master merge: confirm `1.17.0` under `latest`

## Downstream

kiosinc/square-gateway-claude#243 (catalog sync poisons the inventory staleness guard) is **blocked on this releasing as `1.17.0`** — its PR pins `^1.17.0` and needs the partial `{isAvailable}` / `{isAvailable, state}` writes to compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
