### PR TITLE
P38-availability-gaps [feat]: reinstate isHidden in availability types + amend contract #66 (#134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ Each business has 8 singleton root documents that hold denormalized maps of thei
 │   ├── /options/{id}
 │   ├── /taxRates/{id}
 │   ├── /discounts/{id}
-│   └── /serviceCharges/{id}
+│   ├── /serviceCharges/{id}
+│   └── /inventory/{locationId}         (availability per location)
 ├── /public/surfaces
 │   ├── /menus/{id}
 │   ├── /menuGroups/{id}
@@ -151,8 +152,6 @@ Each business has 8 singleton root documents that hold denormalized maps of thei
 │   ├── /surfaceConfigurations/{id}
 │   ├── /checkoutOptions/{id}
 │   └── /collections/{id}
-├── /public/inventory
-│   └── /inventory/{locationId}         (availability per location)
 ├── /public/locations
 │   └── /locations/{id}
 ├── /private/connectedAccounts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kiosinc/restaurant-core-claude",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "license": "ISC",
       "devDependencies": {
         "@google-cloud/functions-framework": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/domain/services/AvailabilityService.ts
+++ b/src/domain/services/AvailabilityService.ts
@@ -13,8 +13,7 @@ export interface OptionAvailability {
   isAvailable: boolean;
   count?: number;
   state?: 'inStock' | 'soldOut';
-  // #134: Remy-owned merchant manual hide. Backend never writes it; clients
-  // treat isHidden === true as "do not render", independent of isAvailable/state.
+  // #134: same semantics as ProductAvailability.isHidden above.
   isHidden?: boolean;
   timestamp?: string;
 }

--- a/src/domain/services/AvailabilityService.ts
+++ b/src/domain/services/AvailabilityService.ts
@@ -3,6 +3,9 @@ import { PathResolver } from '../../persistence/firestore/PathResolver';
 export interface ProductAvailability {
   isAvailable: boolean;
   state?: 'inStock' | 'soldOut';
+  // #134: Remy-owned merchant manual hide. Backend never writes it; clients
+  // treat isHidden === true as "do not render", independent of isAvailable/state.
+  isHidden?: boolean;
   timestamp?: string;
 }
 
@@ -10,6 +13,9 @@ export interface OptionAvailability {
   isAvailable: boolean;
   count?: number;
   state?: 'inStock' | 'soldOut';
+  // #134: Remy-owned merchant manual hide. Backend never writes it; clients
+  // treat isHidden === true as "do not render", independent of isAvailable/state.
+  isHidden?: boolean;
   timestamp?: string;
 }
 

--- a/src/domain/services/__tests__/AvailabilityService.test.ts
+++ b/src/domain/services/__tests__/AvailabilityService.test.ts
@@ -185,6 +185,49 @@ describe('AvailabilityService', () => {
     });
   });
 
+  // #134: isHidden is Remy-owned (merchant manual hide). Backend writers never
+  // set it, but the service must pass it through untouched when a caller does,
+  // and omit it entirely when absent (merge-set writes only provided keys).
+  describe('isHidden passthrough (#134)', () => {
+    it('setProductAvailability passes isHidden through the merge payload', async () => {
+      await setProductAvailability('biz-1', 'loc-1', 'prod-1', { isAvailable: true, isHidden: true });
+
+      expect(mockDocSet).toHaveBeenCalledWith(
+        { products: { 'prod-1': { isAvailable: true, isHidden: true } } },
+        { merge: true },
+      );
+    });
+
+    it('setOptionAvailability passes isHidden through the merge payload', async () => {
+      await setOptionAvailability('biz-1', 'loc-1', 'opt-1', { isAvailable: true, isHidden: false });
+
+      expect(mockDocSet).toHaveBeenCalledWith(
+        { options: { 'opt-1': { isAvailable: true, isHidden: false } } },
+        { merge: true },
+      );
+    });
+
+    it('omitting isHidden writes no isHidden key', async () => {
+      await setProductAvailability('biz-1', 'loc-1', 'prod-1', { isAvailable: true });
+
+      expect(mockDocSet.mock.calls[0][0].products['prod-1']).not.toHaveProperty('isHidden');
+    });
+
+    it('getAvailability reads back entries carrying isHidden', async () => {
+      mockDocGet.mockResolvedValue({
+        exists: true,
+        data: () => ({
+          products: { 'prod-1': { isAvailable: true, isHidden: true } },
+          options: { 'opt-1': { isAvailable: true, isHidden: true } },
+        }),
+      });
+
+      const result = await getAvailability('biz-1', 'loc-1');
+      expect(result!.products['prod-1'].isHidden).toBe(true);
+      expect(result!.options['opt-1'].isHidden).toBe(true);
+    });
+  });
+
   describe('setProductAvailabilityBatch', () => {
     it('merge-sets multiple products under products', async () => {
       await setProductAvailabilityBatch('biz-1', 'loc-1', {


### PR DESCRIPTION
Closes #134

## Scope

**In:**
- Contract #66 amended in place (body edit + amendment comment [#66 (comment)](https://github.com/kiosinc/restaurant-core-claude/issues/66#issuecomment-5234258937)): Firestore path corrected to `public/catalog/inventory/{locationId}`; `isHidden` reinstated with locked semantics (Remy-owned merchant manual hide; backend never writes it; `isHidden === true` = "do not render", independent of `isAvailable`/`state`); doc shape widened to optional `count`/`state`/`timestamp` (partial entries, per rcc 1.17.0 + square-gateway#250); third-writer (catalog sync) conflict rule added verbatim per the P38 orchestrator decisions; remy consumer-checklist line corrected
- `isHidden?: boolean` added to `ProductAvailability` and `OptionAvailability` in `src/domain/services/AvailabilityService.ts` (types now declare the field Remy already writes in prod)
- 4 passthrough tests (`isHidden passthrough (#134)`) covering merge-payload write, omission, and read-back
- README Firestore tree corrected: availability doc moved under `/public/catalog`, bogus `/public/inventory` block removed
- Version bump 1.17.0 → 1.18.0 (minor, additive published type — per PROMOTION.md, matching #142 precedent)

**Out:**
- kios-commons-types widening (`count`/`state`/`timestamp` → optional; `isHidden` already present there via kios-commons-types#45) — filed as kiosinc/kios-commons-types#67 and linked from #134
- No behavior change anywhere — no writer/reader logic touched; catalog-sync behavior itself shipped in square-gateway-claude#250
- Dead `PathResolver.inventoryRootDoc` left in place (published-API removal out of scope)
- `archive/ISSUE_35_PLAN.md` stale path left as-is (archived doc)

## Summary
- Aligns contract #66 and rcc types with what already runs in prod; purely additive optional field + documentation
- The third-writer rule text supersedes the pre-#250 wording ("catalog sync owns isAvailable only; never overwrites state/count/timestamp on existing entries")

## Test plan
- [x] `npm run tsc` clean
- [x] `npm test` — 79 files, 733 tests passing (incl. 4 new)
- [x] `npx eslint` — 0 errors on touched files (16 full-repo errors pre-existing on base, verified via stash comparison)
- [ ] Verify #66 renders correctly (path line, ts block with `isHidden?`, semantics table, §2 third-writer bullet) and remains Closed
- [ ] Verify kiosinc/kios-commons-types#67 scope matches amended contract §1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
