### PR TITLE
P39-sync-page-writes [feat]: open-read FeatureFlagService with pass-through flags (#140)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiosinc/restaurant-core-claude",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/domain/services/FeatureFlagService.ts
+++ b/src/domain/services/FeatureFlagService.ts
@@ -18,10 +18,8 @@ import { getFirestore } from 'firebase-admin/firestore';
  * - The index signature disables compile-time typo checking on flag property
  *   access, so consumers must spell flag names carefully.
  *
- * Sanitization: non-boolean doc values are dropped. For known keys this means
- * they fall back to their `DEFAULT_FLAGS` value (an intentional change from the
- * previous raw `??` pass-through, which let non-boolean truthy/falsy values
- * through).
+ * Sanitization: non-boolean doc values are dropped (logged as a warning);
+ * known keys with a non-boolean value fall back to their `DEFAULT_FLAGS` value.
  */
 export interface WriteModelFlags {
   [key: string]: boolean | undefined;
@@ -64,16 +62,16 @@ export function createFlagService() {
       const db = getFirestore();
       const doc = await db.collection('config').doc('writeModelFlags').get();
 
-      if (!doc.exists) {
-        cachedFlags = { ...DEFAULT_FLAGS };
-        cacheTimestamp = now;
-        return cachedFlags;
-      }
-
-      const data = doc.data()!;
+      const data = doc.exists ? doc.data()! : {};
       const booleanFields = Object.fromEntries(
         Object.entries(data).filter(([, v]) => typeof v === 'boolean'),
       );
+      const droppedKeys = Object.keys(data).filter((k) => typeof data[k] !== 'boolean');
+      if (droppedKeys.length > 0) {
+        console.warn(
+          `FeatureFlagService: dropped non-boolean fields from config/writeModelFlags: ${droppedKeys.join(', ')}`,
+        );
+      }
       cachedFlags = { ...DEFAULT_FLAGS, ...booleanFields };
       cacheTimestamp = now;
       return cachedFlags;

--- a/src/domain/services/FeatureFlagService.ts
+++ b/src/domain/services/FeatureFlagService.ts
@@ -1,6 +1,30 @@
 import { getFirestore } from 'firebase-admin/firestore';
 
+/**
+ * Open-read feature flags contract.
+ *
+ * Flags are read from the Firestore doc `/config/writeModelFlags`. Any boolean
+ * field present in that doc is returned by `getFlags()` — consumers define a new
+ * flag by writing the doc field and reading it as `flags.myFlag ?? false`
+ * (defaults-off). Retiring a flag is deleting the doc field. No library change
+ * or publish is needed to add or retire a flag.
+ *
+ * `DEFAULT_FLAGS` covers only the legacy known keys below; unknown keys have no
+ * default (absent → `undefined`).
+ *
+ * Trade-offs of the open contract:
+ * - The doc is flags-only by convention: any boolean field written to
+ *   `/config/writeModelFlags` will appear in `getFlags()` output.
+ * - The index signature disables compile-time typo checking on flag property
+ *   access, so consumers must spell flag names carefully.
+ *
+ * Sanitization: non-boolean doc values are dropped. For known keys this means
+ * they fall back to their `DEFAULT_FLAGS` value (an intentional change from the
+ * previous raw `??` pass-through, which let non-boolean truthy/falsy values
+ * through).
+ */
 export interface WriteModelFlags {
+  [key: string]: boolean | undefined;
   enableMenuRebuild: boolean;
   enableAvailabilityDoc: boolean;
   writeLegacyOptionInventory: boolean;
@@ -47,17 +71,10 @@ export function createFlagService() {
       }
 
       const data = doc.data()!;
-      cachedFlags = {
-        enableMenuRebuild: data.enableMenuRebuild ?? DEFAULT_FLAGS.enableMenuRebuild,
-        enableAvailabilityDoc: data.enableAvailabilityDoc ?? DEFAULT_FLAGS.enableAvailabilityDoc,
-        writeLegacyOptionInventory: data.writeLegacyOptionInventory ?? DEFAULT_FLAGS.writeLegacyOptionInventory,
-        useCascadeEndpoint: data.useCascadeEndpoint ?? DEFAULT_FLAGS.useCascadeEndpoint,
-        disableImageSync: data.disableImageSync ?? DEFAULT_FLAGS.disableImageSync,
-        enableKioskPrincipals: data.enableKioskPrincipals ?? DEFAULT_FLAGS.enableKioskPrincipals,
-        enableAnonUserSweep: data.enableAnonUserSweep ?? DEFAULT_FLAGS.enableAnonUserSweep,
-        writeLegacyFirestorePresence: data.writeLegacyFirestorePresence ?? DEFAULT_FLAGS.writeLegacyFirestorePresence,
-        isImageDownsample: data.isImageDownsample ?? DEFAULT_FLAGS.isImageDownsample,
-      };
+      const booleanFields = Object.fromEntries(
+        Object.entries(data).filter(([, v]) => typeof v === 'boolean'),
+      );
+      cachedFlags = { ...DEFAULT_FLAGS, ...booleanFields };
       cacheTimestamp = now;
       return cachedFlags;
     },

--- a/src/domain/services/__tests__/FeatureFlagService.test.ts
+++ b/src/domain/services/__tests__/FeatureFlagService.test.ts
@@ -141,4 +141,119 @@ describe('FeatureFlagService', () => {
     await service2.getFlags();
     expect(mockDocGet).toHaveBeenCalledTimes(3);
   });
+
+  it('passes through unknown boolean keys from the doc', async () => {
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ isPageLevelCatalogWrites: true, someOtherNewFlag: false }),
+    });
+
+    const flags = await getFlags();
+    expect(flags.isPageLevelCatalogWrites).toBe(true);
+    expect(flags.someOtherNewFlag).toBe(false);
+    expect(flags.enableMenuRebuild).toBe(true);
+  });
+
+  it('drops unknown non-boolean values (string, number, null, object)', async () => {
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        flagA: 'yes',
+        flagB: 1,
+        flagC: null,
+        flagD: { nested: true },
+        realFlag: true,
+      }),
+    });
+
+    const flags = await getFlags();
+    expect(flags.flagA).toBeUndefined();
+    expect(flags.flagB).toBeUndefined();
+    expect(flags.flagC).toBeUndefined();
+    expect(flags.flagD).toBeUndefined();
+    expect(flags.realFlag).toBe(true);
+  });
+
+  it('sanitizes non-boolean values on known keys to their defaults', async () => {
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        enableMenuRebuild: 'false',
+        writeLegacyFirestorePresence: 0,
+        disableImageSync: true,
+      }),
+    });
+
+    const flags = await getFlags();
+    // Non-boolean values on known keys fall back to defaults, not raw pass-through
+    expect(flags.enableMenuRebuild).toBe(true);
+    expect(flags.writeLegacyFirestorePresence).toBe(true);
+    // Valid boolean passes through
+    expect(flags.disableImageSync).toBe(true);
+  });
+
+  it('unknown keys absent from the doc read as undefined', async () => {
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ enableMenuRebuild: false }),
+    });
+
+    const flags = await getFlags();
+    expect(flags.isPageLevelCatalogWrites).toBeUndefined();
+    expect(flags.isPageLevelCatalogWrites ?? false).toBe(false);
+  });
+
+  it('merges defaults with doc values as a whole object', async () => {
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ useCascadeEndpoint: true, newFlag: true }),
+    });
+
+    const flags = await getFlags();
+    expect(flags).toEqual({
+      enableMenuRebuild: true,
+      enableAvailabilityDoc: true,
+      writeLegacyOptionInventory: false,
+      useCascadeEndpoint: true,
+      disableImageSync: false,
+      enableKioskPrincipals: false,
+      enableAnonUserSweep: false,
+      writeLegacyFirestorePresence: true,
+      isImageDownsample: false,
+      newFlag: true,
+    });
+  });
+
+  it('caches pass-through flags within TTL', async () => {
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ isPageLevelCatalogWrites: true }),
+    });
+
+    const first = await getFlags();
+    const second = await getFlags();
+
+    expect(mockDocGet).toHaveBeenCalledTimes(1);
+    expect(first.isPageLevelCatalogWrites).toBe(true);
+    expect(second.isPageLevelCatalogWrites).toBe(true);
+  });
+
+  it('unknown boolean key retired from doc disappears after cache clear', async () => {
+    mockDocGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => ({ tempFlag: true }),
+    });
+
+    const before = await getFlags();
+    expect(before.tempFlag).toBe(true);
+
+    clearFlagCache();
+    mockDocGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => ({}),
+    });
+
+    const after = await getFlags();
+    expect(after.tempFlag).toBeUndefined();
+  });
 });

--- a/src/domain/services/__tests__/FeatureFlagService.test.ts
+++ b/src/domain/services/__tests__/FeatureFlagService.test.ts
@@ -9,6 +9,19 @@ vi.mock('firebase-admin/firestore', () => ({
   getFirestore: () => ({ collection: mockCollection }),
 }));
 
+// Mirror of the service's DEFAULT_FLAGS (module-private) for whole-object assertions.
+const EXPECTED_DEFAULTS = {
+  enableMenuRebuild: true,
+  enableAvailabilityDoc: true,
+  writeLegacyOptionInventory: false,
+  useCascadeEndpoint: false,
+  disableImageSync: false,
+  enableKioskPrincipals: false,
+  enableAnonUserSweep: false,
+  writeLegacyFirestorePresence: true,
+  isImageDownsample: false,
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   clearFlagCache();
@@ -19,17 +32,7 @@ describe('FeatureFlagService', () => {
     mockDocGet.mockResolvedValue({ exists: false });
 
     const flags = await getFlags();
-    expect(flags).toEqual({
-      enableMenuRebuild: true,
-      enableAvailabilityDoc: true,
-      writeLegacyOptionInventory: false,
-      useCascadeEndpoint: false,
-      disableImageSync: false,
-      enableKioskPrincipals: false,
-      enableAnonUserSweep: false,
-      writeLegacyFirestorePresence: true,
-      isImageDownsample: false,
-    });
+    expect(flags).toEqual(EXPECTED_DEFAULTS);
   });
 
   it('reads flags from Firestore doc', async () => {
@@ -155,6 +158,7 @@ describe('FeatureFlagService', () => {
   });
 
   it('drops unknown non-boolean values (string, number, null, object)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     mockDocGet.mockResolvedValue({
       exists: true,
       data: () => ({
@@ -172,9 +176,14 @@ describe('FeatureFlagService', () => {
     expect(flags.flagC).toBeUndefined();
     expect(flags.flagD).toBeUndefined();
     expect(flags.realFlag).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('dropped non-boolean fields'),
+    );
+    warnSpy.mockRestore();
   });
 
   it('sanitizes non-boolean values on known keys to their defaults', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     mockDocGet.mockResolvedValue({
       exists: true,
       data: () => ({
@@ -190,6 +199,7 @@ describe('FeatureFlagService', () => {
     expect(flags.writeLegacyFirestorePresence).toBe(true);
     // Valid boolean passes through
     expect(flags.disableImageSync).toBe(true);
+    warnSpy.mockRestore();
   });
 
   it('unknown keys absent from the doc read as undefined', async () => {
@@ -200,7 +210,6 @@ describe('FeatureFlagService', () => {
 
     const flags = await getFlags();
     expect(flags.isPageLevelCatalogWrites).toBeUndefined();
-    expect(flags.isPageLevelCatalogWrites ?? false).toBe(false);
   });
 
   it('merges defaults with doc values as a whole object', async () => {
@@ -210,32 +219,7 @@ describe('FeatureFlagService', () => {
     });
 
     const flags = await getFlags();
-    expect(flags).toEqual({
-      enableMenuRebuild: true,
-      enableAvailabilityDoc: true,
-      writeLegacyOptionInventory: false,
-      useCascadeEndpoint: true,
-      disableImageSync: false,
-      enableKioskPrincipals: false,
-      enableAnonUserSweep: false,
-      writeLegacyFirestorePresence: true,
-      isImageDownsample: false,
-      newFlag: true,
-    });
-  });
-
-  it('caches pass-through flags within TTL', async () => {
-    mockDocGet.mockResolvedValue({
-      exists: true,
-      data: () => ({ isPageLevelCatalogWrites: true }),
-    });
-
-    const first = await getFlags();
-    const second = await getFlags();
-
-    expect(mockDocGet).toHaveBeenCalledTimes(1);
-    expect(first.isPageLevelCatalogWrites).toBe(true);
-    expect(second.isPageLevelCatalogWrites).toBe(true);
+    expect(flags).toEqual({ ...EXPECTED_DEFAULTS, useCascadeEndpoint: true, newFlag: true });
   });
 
   it('unknown boolean key retired from doc disappears after cache clear', async () => {


### PR DESCRIPTION
Closes #140

## Scope

**In:**
- `getFlags()` now returns every boolean field in `/config/writeModelFlags` — consumers define a new flag by writing the doc field and reading `flags.myFlag ?? false`; retiring a flag is deleting the field. No library publish needed for either.
- `WriteModelFlags` gains a `[key: string]: boolean | undefined` index signature (additive, non-breaking for all consumers).
- Non-boolean doc values are dropped with a `console.warn` naming the dropped keys; known keys with a non-boolean value fall back to their `DEFAULT_FLAGS` value (intentional divergence from the previous raw `??` pass-through, called out in the issue).
- 6 new tests (pass-through, non-boolean drop + warn, known-key sanitization, absent-unknown-key, whole-object merge, flag retirement after cache clear); all 9 existing tests unchanged.
- Version bump 1.17.0 → 1.18.0 (minor).

**Out:**
- Defining `isPageLevelCatalogWrites` — consumer-side, kiosinc/square-gateway-claude#244.
- Any additions to `DEFAULT_FLAGS` (legacy known keys only).
- Publishing — orchestrator runs the prerelease Cloud Build trigger against `project/39` after merge (per P39 decisions).

## Summary
- Replaced the field-by-field `??` mapping with a sanitizing pass-through: `{ ...DEFAULT_FLAGS, ...booleanDocFields }`; doc-missing flows through the same merge (zero boolean fields), removing the duplicate cache-write path.
- Cache TTL (60s), `clearCache`, and singleton exports untouched.
- Header comment documents the open-read contract, the flags-only-doc convention, and the typo-checking trade-off of the index signature.
- Consumer-assumption evidence (issue AC): `rg 'keyof WriteModelFlags'` across square-gateway-claude, businesses, cloud-functions, firestore-functions = **zero matches**; all consumers property-access named keys, so the index signature is non-breaking.

## Test plan
- [x] Automated tests pass — `npm test`: 79 files, 735 tests green; `npm run tsc` clean; `npx eslint` on touched files: 0 errors (2 pre-existing warnings only)
- No manual verification needed — Firestore is mocked, no runtime/UI behavior; cross-repo validation happens when gateway pins the `-dev.<sha>` prerelease (orchestrator step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JUgX8kdLPJqjKxxdSQZa3h