### PR TITLE
P36-ref-integrity [feat]: AvailabilityService entry-removal APIs (#133)

### DIFF
--- a/src/domain/services/AvailabilityService.ts
+++ b/src/domain/services/AvailabilityService.ts
@@ -1,3 +1,4 @@
+import { FieldValue, GrpcStatus } from 'firebase-admin/firestore';
 import { PathResolver } from '../../persistence/firestore/PathResolver';
 
 export interface ProductAvailability {
@@ -88,4 +89,67 @@ export async function getOptionTimestamp(
   const doc = await getAvailability(businessId, locationId);
   const ts = doc?.options?.[optionId]?.timestamp;
   return ts ? new Date(ts) : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Entry removal (#133)
+//
+// Removal is the ONE deliberate exception to this file's merge-set convention
+// (see the "#70 regression" tests). Two reasons, both load-bearing:
+//
+// 1. FieldValue.delete() is honoured ONLY at the root of an update() map, so
+//    the key must be the dotted string `options.<id>` / `products.<id>`. The
+//    nested form — update({ options: { <id>: FieldValue.delete() } }) — is
+//    rejected by the client before it ever reaches the server.
+// 2. Do NOT "fix" this back to set(..., { merge: true }). A merge-set upserts,
+//    so pruning a location that has no AvailabilityDoc would materialise an
+//    empty document and flip getAvailability() from null to {products:{},
+//    options:{}}. A referential-integrity cleanup must not create garbage docs.
+// ---------------------------------------------------------------------------
+
+// update() carries an implicit "document must exist" precondition; a missing
+// doc surfaces as gRPC NOT_FOUND (5), which is the expected no-op for a prune.
+// The check stays narrow on purpose: a blanket swallow would also hide
+// PERMISSION_DENIED (7), RESOURCE_EXHAUSTED (8), INVALID_ARGUMENT (3) and
+// deadline errors, silently turning a broken sync into a successful no-op.
+function isDocumentNotFound(err: unknown): boolean {
+  return (err as { code?: number }).code === GrpcStatus.NOT_FOUND;
+}
+
+async function removeAvailabilityEntries(
+  businessId: string,
+  locationId: string,
+  field: 'products' | 'options',
+  ids: string[],
+): Promise<void> {
+  // update() rejects an empty field map SYNCHRONOUSLY ("At least one field must
+  // be updated."), so guard before issuing any RPC.
+  if (ids.length === 0) return;
+
+  // One accumulator, one update() call per location, regardless of id count.
+  const deletes: Record<string, FieldValue> = {};
+  for (const id of ids) {
+    deletes[`${field}.${id}`] = FieldValue.delete();
+  }
+
+  const docRef = PathResolver.availabilityDoc(businessId, locationId);
+  try {
+    await docRef.update(deletes);
+  } catch (err) {
+    if (!isDocumentNotFound(err)) throw err;
+  }
+}
+
+export async function removeOptionAvailability(businessId: string, locationId: string, optionIds: string[]): Promise<void> {
+  await removeAvailabilityEntries(businessId, locationId, 'options', optionIds);
+}
+
+export async function removeProductAvailability(businessId: string, locationId: string, productIds: string[]): Promise<void> {
+  await removeAvailabilityEntries(businessId, locationId, 'products', productIds);
+}
+
+export async function deleteAvailabilityDoc(businessId: string, locationId: string): Promise<void> {
+  // delete() has no existence precondition — it is already idempotent on a
+  // missing document, so an exists-check or try/catch here would be dead code.
+  await PathResolver.availabilityDoc(businessId, locationId).delete();
 }

--- a/src/domain/services/AvailabilityService.ts
+++ b/src/domain/services/AvailabilityService.ts
@@ -126,11 +126,9 @@ async function removeAvailabilityEntries(
   // be updated."), so guard before issuing any RPC.
   if (ids.length === 0) return;
 
-  // One accumulator, one update() call per location, regardless of id count.
-  const deletes: Record<string, FieldValue> = {};
-  for (const id of ids) {
-    deletes[`${field}.${id}`] = FieldValue.delete();
-  }
+  // All ids for one location coalesce into a single update() — same delete-map
+  // idiom as CascadeRelationshipHandler.
+  const deletes = Object.fromEntries(ids.map((id) => [`${field}.${id}`, FieldValue.delete()]));
 
   const docRef = PathResolver.availabilityDoc(businessId, locationId);
   try {

--- a/src/domain/services/__tests__/AvailabilityService.test.ts
+++ b/src/domain/services/__tests__/AvailabilityService.test.ts
@@ -6,13 +6,21 @@ import {
   setProductAvailabilityBatch,
   updateAvailability,
   getOptionTimestamp,
+  removeOptionAvailability,
+  removeProductAvailability,
+  deleteAvailabilityDoc,
 } from '../AvailabilityService';
+import { PathResolver } from '../../../persistence/firestore/PathResolver';
 
 const mockDocGet = vi.fn();
 const mockDocSet = vi.fn();
+const mockDocUpdate = vi.fn();
+const mockDocDelete = vi.fn();
 const mockAvailabilityDoc = {
   get: mockDocGet,
   set: mockDocSet,
+  update: mockDocUpdate,
+  delete: mockDocDelete,
 };
 
 vi.mock('../../../persistence/firestore/PathResolver', () => ({
@@ -21,9 +29,16 @@ vi.mock('../../../persistence/firestore/PathResolver', () => ({
   },
 }));
 
+vi.mock('firebase-admin/firestore', () => ({
+  FieldValue: { delete: () => '$$FIELD_DELETE$$' },
+  GrpcStatus: { NOT_FOUND: 5 },
+}));
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockDocSet.mockResolvedValue(undefined);
+  mockDocUpdate.mockResolvedValue(undefined);
+  mockDocDelete.mockResolvedValue(undefined);
 });
 
 describe('AvailabilityService', () => {
@@ -273,6 +288,160 @@ describe('AvailabilityService', () => {
       });
       const result = await getOptionTimestamp('biz-1', 'loc-1', 'opt-1');
       expect(result).toBeUndefined();
+    });
+  });
+});
+
+// Removal is the deliberate inversion of the #70 merge-set convention: dotted
+// root-level keys + update(), so that pruning a location with no availability
+// doc is a no-op instead of materialising an empty document.
+describe('entry removal (#133)', () => {
+  describe('removeOptionAvailability', () => {
+    it('deletes a single option via a root-level dotted field path', async () => {
+      await removeOptionAvailability('biz-1', 'loc-1', ['opt-1']);
+
+      expect(mockDocUpdate).toHaveBeenCalledWith({ 'options.opt-1': '$$FIELD_DELETE$$' });
+      const payload = mockDocUpdate.mock.calls[0][0];
+      expect(Object.keys(payload)).not.toContain('options');
+    });
+
+    it('coalesces multiple option ids into exactly one update() call', async () => {
+      await removeOptionAvailability('biz-1', 'loc-1', ['opt-1', 'opt-2', 'opt-3']);
+
+      expect(mockDocUpdate).toHaveBeenCalledTimes(1);
+      const payload = mockDocUpdate.mock.calls[0][0];
+      expect(Object.keys(payload)).toHaveLength(3);
+      expect(payload).toEqual({
+        'options.opt-1': '$$FIELD_DELETE$$',
+        'options.opt-2': '$$FIELD_DELETE$$',
+        'options.opt-3': '$$FIELD_DELETE$$',
+      });
+    });
+
+    it('issues no write when the id list is empty', async () => {
+      await expect(removeOptionAvailability('biz-1', 'loc-1', [])).resolves.toBeUndefined();
+
+      expect(mockDocUpdate).not.toHaveBeenCalled();
+      expect(mockDocSet).not.toHaveBeenCalled();
+    });
+
+    it('resolves silently when the location doc does not exist (NOT_FOUND)', async () => {
+      mockDocUpdate.mockRejectedValue(
+        Object.assign(new Error('5 NOT_FOUND: no entity to update'), { code: 5 }),
+      );
+
+      await expect(removeOptionAvailability('biz-1', 'loc-1', ['opt-1'])).resolves.toBeUndefined();
+    });
+
+    it('propagates PERMISSION_DENIED instead of swallowing it', async () => {
+      mockDocUpdate.mockRejectedValue(
+        Object.assign(new Error('7 PERMISSION_DENIED: missing permissions'), { code: 7 }),
+      );
+
+      await expect(removeOptionAvailability('biz-1', 'loc-1', ['opt-1'])).rejects.toThrow('PERMISSION_DENIED');
+    });
+
+    it('propagates RESOURCE_EXHAUSTED instead of swallowing it', async () => {
+      mockDocUpdate.mockRejectedValue(
+        Object.assign(new Error('8 RESOURCE_EXHAUSTED: quota exceeded'), { code: 8 }),
+      );
+
+      await expect(removeOptionAvailability('biz-1', 'loc-1', ['opt-1'])).rejects.toThrow('RESOURCE_EXHAUSTED');
+    });
+
+    it('propagates an error that carries no code', async () => {
+      mockDocUpdate.mockRejectedValue(new Error('boom'));
+
+      await expect(removeOptionAvailability('biz-1', 'loc-1', ['opt-1'])).rejects.toThrow('boom');
+    });
+
+    it('never upserts via set() (a merge-set would materialise an empty doc)', async () => {
+      await removeOptionAvailability('biz-1', 'loc-1', ['opt-1']);
+
+      expect(mockDocSet).not.toHaveBeenCalled();
+    });
+
+    it('targets the per-location availability doc', async () => {
+      await removeOptionAvailability('biz-1', 'loc-1', ['opt-1']);
+
+      expect(vi.mocked(PathResolver.availabilityDoc)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(PathResolver.availabilityDoc)).toHaveBeenCalledWith('biz-1', 'loc-1');
+    });
+  });
+
+  describe('removeProductAvailability', () => {
+    it('deletes a single product via a root-level dotted field path', async () => {
+      await removeProductAvailability('biz-1', 'loc-1', ['prod-1']);
+
+      expect(mockDocUpdate).toHaveBeenCalledWith({ 'products.prod-1': '$$FIELD_DELETE$$' });
+      const payload = mockDocUpdate.mock.calls[0][0];
+      expect(Object.keys(payload)).not.toContain('products');
+    });
+
+    it('coalesces multiple product ids into exactly one update() call', async () => {
+      await removeProductAvailability('biz-1', 'loc-1', ['prod-1', 'prod-2', 'prod-3']);
+
+      expect(mockDocUpdate).toHaveBeenCalledTimes(1);
+      const payload = mockDocUpdate.mock.calls[0][0];
+      expect(Object.keys(payload)).toHaveLength(3);
+      expect(payload).toEqual({
+        'products.prod-1': '$$FIELD_DELETE$$',
+        'products.prod-2': '$$FIELD_DELETE$$',
+        'products.prod-3': '$$FIELD_DELETE$$',
+      });
+    });
+
+    it('issues no write when the id list is empty', async () => {
+      await expect(removeProductAvailability('biz-1', 'loc-1', [])).resolves.toBeUndefined();
+
+      expect(mockDocUpdate).not.toHaveBeenCalled();
+      expect(mockDocSet).not.toHaveBeenCalled();
+    });
+
+    it('resolves silently when the location doc does not exist (NOT_FOUND)', async () => {
+      mockDocUpdate.mockRejectedValue(
+        Object.assign(new Error('5 NOT_FOUND: no entity to update'), { code: 5 }),
+      );
+
+      await expect(removeProductAvailability('biz-1', 'loc-1', ['prod-1'])).resolves.toBeUndefined();
+    });
+
+    it('propagates non-NOT_FOUND errors', async () => {
+      mockDocUpdate.mockRejectedValue(
+        Object.assign(new Error('7 PERMISSION_DENIED: missing permissions'), { code: 7 }),
+      );
+
+      await expect(removeProductAvailability('biz-1', 'loc-1', ['prod-1'])).rejects.toThrow('PERMISSION_DENIED');
+    });
+
+    it('writes only under products, never options', async () => {
+      await removeProductAvailability('biz-1', 'loc-1', ['prod-1', 'prod-2']);
+
+      const payload = mockDocUpdate.mock.calls[0][0];
+      expect(Object.keys(payload).some((key) => key.startsWith('options.'))).toBe(false);
+    });
+  });
+
+  describe('deleteAvailabilityDoc', () => {
+    it('deletes the whole per-location doc', async () => {
+      await deleteAvailabilityDoc('biz-1', 'loc-1');
+
+      expect(mockDocDelete).toHaveBeenCalledTimes(1);
+      expect(mockDocDelete).toHaveBeenCalledWith();
+      expect(vi.mocked(PathResolver.availabilityDoc)).toHaveBeenCalledWith('biz-1', 'loc-1');
+    });
+
+    it('does not pre-read the doc (delete() is already idempotent)', async () => {
+      await deleteAvailabilityDoc('biz-1', 'loc-1');
+
+      expect(mockDocGet).not.toHaveBeenCalled();
+      expect(mockDocUpdate).not.toHaveBeenCalled();
+    });
+
+    it('propagates delete() failures', async () => {
+      mockDocDelete.mockRejectedValue(new Error('boom'));
+
+      await expect(deleteAvailabilityDoc('biz-1', 'loc-1')).rejects.toThrow('boom');
     });
   });
 });

--- a/src/domain/services/__tests__/AvailabilityService.test.ts
+++ b/src/domain/services/__tests__/AvailabilityService.test.ts
@@ -292,9 +292,8 @@ describe('AvailabilityService', () => {
   });
 });
 
-// Removal is the deliberate inversion of the #70 merge-set convention: dotted
-// root-level keys + update(), so that pruning a location with no availability
-// doc is a no-op instead of materialising an empty document.
+// Removal deliberately inverts the #70 merge-set convention — see the
+// "Entry removal (#133)" comment block in AvailabilityService.ts for why.
 describe('entry removal (#133)', () => {
   describe('removeOptionAvailability', () => {
     it('deletes a single option via a root-level dotted field path', async () => {

--- a/src/domain/services/index.ts
+++ b/src/domain/services/index.ts
@@ -39,4 +39,7 @@ export {
   setProductAvailabilityBatch,
   updateAvailability,
   getOptionTimestamp,
+  removeOptionAvailability,
+  removeProductAvailability,
+  deleteAvailabilityDoc,
 } from './AvailabilityService';


### PR DESCRIPTION
Closes #133

## Scope

**In:**
- `removeOptionAvailability(businessId, locationId, optionIds)` — prunes `options.{id}` entries from a location's AvailabilityDoc.
- `removeProductAvailability(businessId, locationId, productIds)` — prunes `products.{id}` entries.
- `deleteAvailabilityDoc(businessId, locationId)` — deletes the whole per-location doc (location deletion).
- All three exported through `Domain.Services` — the exact access path square-gateway-claude#239 is written against. Signatures are byte-identical to the issue spec.
- Pruning a location that has no AvailabilityDoc is a silent no-op; every other Firestore error still propagates.
- 18 new unit tests (39 in the file, 747 repo-wide, all green).

**Out:**
- **No call sites.** Nothing in this repo invokes the new APIs yet — wiring cleanup and location-deletion callers is kiosinc/square-gateway-claude#239, blocked on this publishing.
- **No `package.json` version bump.** Per the P36 orchestrator decision, the bump belongs to the rollup PR into `dev` (which is what triggers the `X.Y.Z-dev.<sha>` prerelease publish under dist-tag `next`). Bumping here would collide with the concurrent #132 wave PR.
- No backfill or one-off prune of AvailabilityDocs that are already stale in prod — this only supplies the API.
- No MenuRebuildService changes (that is #132).

## Summary

- Removal uses dotted root-level keys + `update()`, which is the **only** form the Firestore client accepts: `FieldValue.delete()` is honoured solely at the root of an update map, and a dotted key replaces just that entry without rewriting its siblings.
- This deliberately inverts the file's `set(..., { merge: true })` convention (guarded by the #70 regression tests), because a merge-set upserts — pruning a location with no AvailabilityDoc would materialise an empty document and flip `getAvailability()` from `null` to `{}`. A code comment records why, so it does not get "fixed" back.
- `update()` carries an implicit must-exist precondition, so a missing doc surfaces as gRPC `NOT_FOUND`. The catch is narrowed to `GrpcStatus.NOT_FOUND` only — a blanket swallow would hide PERMISSION_DENIED / RESOURCE_EXHAUSTED / deadline errors and turn a broken sync into a silent success.
- All ids for one location coalesce into a **single** `update()` regardless of count (no `WriteBatch` — the repo has none), reusing the same `Object.fromEntries(... FieldValue.delete())` delete-map idiom as `CascadeRelationshipHandler`.
- Empty id array issues no RPC at all — `update({})` throws *synchronously*, so a caller's `.catch()` would miss it.
- `deleteAvailabilityDoc` is a bare `delete()`: it has no existence precondition and is already idempotent, so an exists-check would be dead code (a test pins the absence of the pre-read).

## Test plan

- [x] `npx vitest run` — 79 files / 747 tests pass (21 pre-existing in this file untouched, 18 new)
- [x] `npx tsc --noEmit` clean; `npm run tsc` builds `lib/`
- [x] `npx eslint` on the touched files — 0 errors (9 pre-existing `no-non-null-assertion` warnings on untouched lines)
- [x] Published-surface smoke: all three names present in `lib/domain/services/AvailabilityService.d.ts` and `index.d.ts`; `Domain.Services.*` resolves to `function` for each
- [ ] **Emulator (not run — no Firestore emulator in the build environment):** removing one option leaves sibling options and the whole `products` map intact, and creates no literal `"options.<id>"` top-level field
- [ ] **Emulator (not run):** removal against a non-existent location resolves *and* leaves `exists === false` — the decisive check that this did not become a merge-set
- [ ] **Emulator (not run):** `deleteAvailabilityDoc` removes an existing doc and is a silent no-op on a missing one
- [ ] After the rollup merges to `dev` and CI publishes the prerelease, confirm square-gateway-claude#239 compiles against all three imports

## Known follow-up (not a blocker)

`ids` is caller-supplied and unbounded, so a very large prune builds one large update mask. The repo already has a chunking precedent in `FirestoreRepository` if a caller ever passes a whole catalog's worth of deleted ids; left out here to keep the contract surface exactly as specified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VWH4P4z4hRYRZReW4N5Be