### PR TITLE
P36-ref-integrity [feat]: rebuildMenus prunes dangling menuAssets/menuAssetDisplayOrder (#132)

### DIFF
--- a/src/domain/services/FeatureFlagService.ts
+++ b/src/domain/services/FeatureFlagService.ts
@@ -10,6 +10,13 @@ export interface WriteModelFlags {
   enableAnonUserSweep: boolean;
   writeLegacyFirestorePresence: boolean;
   isImageDownsample: boolean;
+  /**
+   * #132 kill switch. When true (default), rebuildMenus prunes menuAssets /
+   * menuAssetDisplayOrder / groupDisplayOrder entries whose backing menuGroup or
+   * collection doc is missing or isDeleted. Flip to false to restore verbatim
+   * preservation; pruning is loss-free, so rollback needs no data restoration.
+   */
+  pruneMenuAssetsOnRebuild: boolean;
 }
 
 const DEFAULT_FLAGS: WriteModelFlags = {
@@ -22,6 +29,7 @@ const DEFAULT_FLAGS: WriteModelFlags = {
   enableAnonUserSweep: false,
   writeLegacyFirestorePresence: true,
   isImageDownsample: false,
+  pruneMenuAssetsOnRebuild: true,
 };
 
 const CACHE_TTL_MS = 60_000;
@@ -57,6 +65,7 @@ export function createFlagService() {
         enableAnonUserSweep: data.enableAnonUserSweep ?? DEFAULT_FLAGS.enableAnonUserSweep,
         writeLegacyFirestorePresence: data.writeLegacyFirestorePresence ?? DEFAULT_FLAGS.writeLegacyFirestorePresence,
         isImageDownsample: data.isImageDownsample ?? DEFAULT_FLAGS.isImageDownsample,
+        pruneMenuAssetsOnRebuild: data.pruneMenuAssetsOnRebuild ?? DEFAULT_FLAGS.pruneMenuAssetsOnRebuild,
       };
       cacheTimestamp = now;
       return cachedFlags;

--- a/src/domain/services/MenuRebuildService.ts
+++ b/src/domain/services/MenuRebuildService.ts
@@ -70,16 +70,21 @@ interface PrunedMenuRefs {
  * collection docs. Recompute them from the docs that actually came back rather than carrying
  * the previous values forward. materializedGroups / materializedCollections are keyed by
  * exactly the ids whose doc existed and was not isDeleted, so they are the survivor set.
+ *
+ * Both the kill-switch-off path and the nothing-to-prune path return the caller's own
+ * references, so a menu with no dangling refs is rewritten byte-identically.
  */
 function pruneDanglingAssetRefs(
+  isPruningEnabled: boolean,
   menuAssets: Record<string, MenuAsset>,
   menuAssetDisplayOrder: string[],
   groupDisplayOrder: string[],
   materializedGroups: Record<string, MenuGroupMeta>,
   materializedCollections: Record<string, MenuCollectionMeta>,
 ): PrunedMenuRefs {
-  const survivingGroupIds = new Set(Object.keys(materializedGroups));
-  const survivingCollectionIds = new Set(Object.keys(materializedCollections));
+  if (!isPruningEnabled) {
+    return { menuAssets, menuAssetDisplayOrder, groupDisplayOrder, prunedIds: [] };
+  }
 
   const keptAssets: Record<string, MenuAsset> = {};
   const prunedIds: string[] = [];
@@ -89,10 +94,10 @@ function pruneDanglingAssetRefs(
       keptAssets[id] = asset;
       continue;
     }
-    const survives = asset.assetType === 'group'
-      ? survivingGroupIds.has(id)
-      : survivingCollectionIds.has(id);
-    if (survives) keptAssets[id] = asset;
+    // The materialized maps are already keyed by the survivor ids — own-key membership is
+    // the survival test, so there is no second index to build.
+    const survivors = asset.assetType === 'group' ? materializedGroups : materializedCollections;
+    if (Object.prototype.hasOwnProperty.call(survivors, id)) keptAssets[id] = asset;
     else prunedIds.push(id);
   }
 
@@ -391,6 +396,11 @@ async function attemptRebuild(
   let prunedIds: string[] = [];
 
   await db.runTransaction(async (t) => {
+    // Firestore retries this callback on contention, and the divergence branch below returns
+    // without setting prunedIds. Reset per attempt so the warn after commit can never report
+    // a prune from an attempt that was rolled back.
+    prunedIds = [];
+
     const freshMenuSnap = await t.get(menuDocRef);
     const existingData = freshMenuSnap.data() ?? {};
 
@@ -404,20 +414,14 @@ async function attemptRebuild(
     const freshGroupDisplayOrder: string[] = existingData.groupDisplayOrder ?? [];
     const freshMenuAssetDisplayOrder: string[] = existingData.menuAssetDisplayOrder ?? [];
 
-    const refs = pruneMenuAssetsOnRebuild
-      ? pruneDanglingAssetRefs(
-        freshMenuAssets,
-        freshMenuAssetDisplayOrder,
-        freshGroupDisplayOrder,
-        materializedGroups,
-        materializedCollections,
-      )
-      : {
-        menuAssets: freshMenuAssets,
-        menuAssetDisplayOrder: freshMenuAssetDisplayOrder,
-        groupDisplayOrder: freshGroupDisplayOrder,
-        prunedIds: [] as string[],
-      };
+    const refs = pruneDanglingAssetRefs(
+      pruneMenuAssetsOnRebuild,
+      freshMenuAssets,
+      freshMenuAssetDisplayOrder,
+      freshGroupDisplayOrder,
+      materializedGroups,
+      materializedCollections,
+    );
     prunedIds = refs.prunedIds;
 
     const merged: MaterializedMenuDoc = {
@@ -446,8 +450,8 @@ async function attemptRebuild(
     t.set(menuDocRef, merged);
   });
 
-  // #132/UC13: log only when something was actually pruned — this runs for every menu on
-  // every rebuild, and a no-op line per menu would drown the signal.
+  // #132: log only when something was actually pruned — this runs for every menu on every
+  // rebuild, and a no-op line per menu would drown the signal.
   if (prunedIds.length > 0) {
     console.warn('[MenuRebuildService] pruned dangling asset refs', {
       businessId,

--- a/src/domain/services/MenuRebuildService.ts
+++ b/src/domain/services/MenuRebuildService.ts
@@ -2,6 +2,7 @@ import { getFirestore } from 'firebase-admin/firestore';
 import { PathResolver } from '../../persistence/firestore/PathResolver';
 import type { MenuAsset, MenuProductMeta, MenuCollectionMeta } from '../surfaces/Menu';
 import type { MenuGroupMeta } from '../surfaces/MenuGroup';
+import { getFlags } from './FeatureFlagService';
 
 export interface RebuildScope {
   menuIds?: string[];
@@ -48,6 +49,67 @@ function extractAssetIdsByType(
   return Object.entries(menuAssets)
     .filter(([, asset]) => asset.assetType === type)
     .map(([id]) => id);
+}
+
+/**
+ * #132: the only asset types attemptRebuild batch-reads backing docs for, and therefore the
+ * only ones it has evidence to prune. 'product' and 'htmlText' assets have no backing doc in
+ * this read set, so they are always preserved verbatim — pruning them would be data loss.
+ */
+const PRUNABLE_ASSET_TYPES: ReadonlySet<MenuAsset['assetType']> = new Set<MenuAsset['assetType']>(['group', 'collection']);
+
+interface PrunedMenuRefs {
+  menuAssets: Record<string, MenuAsset>;
+  menuAssetDisplayOrder: string[];
+  groupDisplayOrder: string[];
+  prunedIds: string[];
+}
+
+/**
+ * #132: menuAssets and its two display orders are a derived index over the menuGroup and
+ * collection docs. Recompute them from the docs that actually came back rather than carrying
+ * the previous values forward. materializedGroups / materializedCollections are keyed by
+ * exactly the ids whose doc existed and was not isDeleted, so they are the survivor set.
+ */
+function pruneDanglingAssetRefs(
+  menuAssets: Record<string, MenuAsset>,
+  menuAssetDisplayOrder: string[],
+  groupDisplayOrder: string[],
+  materializedGroups: Record<string, MenuGroupMeta>,
+  materializedCollections: Record<string, MenuCollectionMeta>,
+): PrunedMenuRefs {
+  const survivingGroupIds = new Set(Object.keys(materializedGroups));
+  const survivingCollectionIds = new Set(Object.keys(materializedCollections));
+
+  const keptAssets: Record<string, MenuAsset> = {};
+  const prunedIds: string[] = [];
+
+  for (const [id, asset] of Object.entries(menuAssets)) {
+    if (!PRUNABLE_ASSET_TYPES.has(asset.assetType)) {
+      keptAssets[id] = asset;
+      continue;
+    }
+    const survives = asset.assetType === 'group'
+      ? survivingGroupIds.has(id)
+      : survivingCollectionIds.has(id);
+    if (survives) keptAssets[id] = asset;
+    else prunedIds.push(id);
+  }
+
+  if (prunedIds.length === 0) {
+    return { menuAssets, menuAssetDisplayOrder, groupDisplayOrder, prunedIds };
+  }
+
+  // Remove only ids we actually pruned, preserving the relative order of survivors. Ids that
+  // were never in menuAssets (legacy menus predate menuAssets and carry only groupDisplayOrder)
+  // are left untouched — pruning must never destroy an order it has no evidence about.
+  const prunedSet = new Set(prunedIds);
+  return {
+    menuAssets: keptAssets,
+    menuAssetDisplayOrder: menuAssetDisplayOrder.filter((id) => !prunedSet.has(id)),
+    groupDisplayOrder: groupDisplayOrder.filter((id) => !prunedSet.has(id)),
+    prunedIds,
+  };
 }
 
 const MAX_REBUILD_RETRIES = 3;
@@ -318,9 +380,15 @@ async function attemptRebuild(
   const materializedGroups = materializeGroups(menuGroups, productMap, categoryMap);
   const materializedCollections = materializeCollections(collections);
 
+  // #132: read the kill switch once, outside the transaction — transaction callbacks are
+  // retried, and a non-transactional read inside a transaction is an anti-pattern. Pruning is
+  // still COMPUTED inside the transaction from the fresh in-transaction read (existingData).
+  const { pruneMenuAssetsOnRebuild } = await getFlags();
+
   // Phase B: Atomic write (inside transaction)
   const menuDocRef = PathResolver.menusCollection(businessId).doc(menu.id);
   let freshData: FirebaseFirestore.DocumentData | undefined;
+  let prunedIds: string[] = [];
 
   await db.runTransaction(async (t) => {
     const freshMenuSnap = await t.get(menuDocRef);
@@ -332,6 +400,25 @@ async function attemptRebuild(
       freshData = existingData;
       return; // Skip write; transaction commits as read-only
     }
+
+    const freshGroupDisplayOrder: string[] = existingData.groupDisplayOrder ?? [];
+    const freshMenuAssetDisplayOrder: string[] = existingData.menuAssetDisplayOrder ?? [];
+
+    const refs = pruneMenuAssetsOnRebuild
+      ? pruneDanglingAssetRefs(
+        freshMenuAssets,
+        freshMenuAssetDisplayOrder,
+        freshGroupDisplayOrder,
+        materializedGroups,
+        materializedCollections,
+      )
+      : {
+        menuAssets: freshMenuAssets,
+        menuAssetDisplayOrder: freshMenuAssetDisplayOrder,
+        groupDisplayOrder: freshGroupDisplayOrder,
+        prunedIds: [] as string[],
+      };
+    prunedIds = refs.prunedIds;
 
     const merged: MaterializedMenuDoc = {
       // Preserve structural fields
@@ -349,15 +436,25 @@ async function attemptRebuild(
 
       // Materialized sections
       groups: materializedGroups,
-      groupDisplayOrder: existingData.groupDisplayOrder ?? [],
+      groupDisplayOrder: refs.groupDisplayOrder,
       collections: materializedCollections,
-      menuAssets: existingData.menuAssets ?? {},
-      menuAssetDisplayOrder: existingData.menuAssetDisplayOrder ?? [],
+      menuAssets: refs.menuAssets,
+      menuAssetDisplayOrder: refs.menuAssetDisplayOrder,
       version: existingData.version ?? menu.data.version,
     };
 
     t.set(menuDocRef, merged);
   });
+
+  // #132/UC13: log only when something was actually pruned — this runs for every menu on
+  // every rebuild, and a no-op line per menu would drown the signal.
+  if (prunedIds.length > 0) {
+    console.warn('[MenuRebuildService] pruned dangling asset refs', {
+      businessId,
+      menuId: menu.id,
+      prunedIds,
+    });
+  }
 
   if (freshData) {
     return { success: false, freshData };

--- a/src/domain/services/__tests__/FeatureFlagService.test.ts
+++ b/src/domain/services/__tests__/FeatureFlagService.test.ts
@@ -29,6 +29,7 @@ describe('FeatureFlagService', () => {
       enableAnonUserSweep: false,
       writeLegacyFirestorePresence: true,
       isImageDownsample: false,
+      pruneMenuAssetsOnRebuild: true,
     });
   });
 
@@ -90,6 +91,26 @@ describe('FeatureFlagService', () => {
 
     const flags = await getFlags();
     expect(flags.isImageDownsample).toBe(true);
+  });
+
+  it('defaults pruneMenuAssetsOnRebuild to true when absent in the doc', async () => {
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ enableMenuRebuild: true }),
+    });
+
+    const flags = await getFlags();
+    expect(flags.pruneMenuAssetsOnRebuild).toBe(true);
+  });
+
+  it('reads pruneMenuAssetsOnRebuild as false when set in the doc', async () => {
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ pruneMenuAssetsOnRebuild: false }),
+    });
+
+    const flags = await getFlags();
+    expect(flags.pruneMenuAssetsOnRebuild).toBe(false);
   });
 
   it('caches result within TTL', async () => {

--- a/src/domain/services/__tests__/MenuRebuildService.test.ts
+++ b/src/domain/services/__tests__/MenuRebuildService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { rebuildMenus, resolveChangedProducts, resolveChangedCategories } from '../MenuRebuildService';
 import {
   BUSINESS_ID,
@@ -22,6 +22,12 @@ vi.mock('firebase-admin/firestore', () => ({
   getFirestore: () => mockDb,
   FieldValue: { delete: () => '$$FIELD_DELETE$$' },
 }));
+
+// #132: MenuRebuildService reads the pruneMenuAssetsOnRebuild kill switch via getFlags().
+// helpers/mockFirestore's doc refs have no .get(), so the real FeatureFlagService cannot run
+// here — and every test needs to toggle the flag anyway.
+const { mockGetFlags } = vi.hoisted(() => ({ mockGetFlags: vi.fn() }));
+vi.mock('../FeatureFlagService', () => ({ getFlags: mockGetFlags }));
 
 // Build the PathResolver collection path mappings
 const MENUS_PATH = `businesses/${BUSINESS_ID}/public/surfaces/menus`;
@@ -49,6 +55,10 @@ vi.mock('../../../persistence/firestore/PathResolver', () => ({
 
 beforeEach(() => {
   resetMockFirestore();
+
+  // #132: resetMockFirestore() calls vi.clearAllMocks(), which drops the mock's resolved
+  // value — restore the default (flag on) after it.
+  mockGetFlags.mockResolvedValue({ pruneMenuAssetsOnRebuild: true });
 
   // Register fixture data
   registerCollection(MENUS_PATH, menus);
@@ -584,6 +594,10 @@ describe('MenuRebuildService', () => {
       await rebuildMenus(BUSINESS_ID);
       expect(transactionSets).toHaveLength(1);
       expect(transactionSets[0].data.groups).toEqual({});
+      // #132: the deleted group's asset ref and display-order entries go with it
+      expect(transactionSets[0].data.menuAssets).toEqual({});
+      expect(transactionSets[0].data.menuAssetDisplayOrder).toEqual([]);
+      expect(transactionSets[0].data.groupDisplayOrder).toEqual([]);
     });
 
     it('includes menu group added without legacy assetId field', async () => {
@@ -628,6 +642,347 @@ describe('MenuRebuildService', () => {
       expect(transactionSets).toHaveLength(3);
       const menuIds = transactionSets.map((s) => s.ref._docId).sort();
       expect(menuIds).toEqual(['CcUqgkBxEnk1qYaNZ3K2', 'LShRjmDOXBNL7yVSD65V', 'TdGQqmNhA3AjNeoyYrQn'].sort());
+    });
+  });
+
+  // ─── #132 — prunes dangling menuAssets refs ─────────────────────────
+
+  describe('#132 — prunes dangling menuAssets refs', () => {
+    const PRUNE_MENU = 'prune-menu';
+    const LIVE_GROUP = '0YRxtglWpkDyxcW8WCTD';
+    const LIVE_GROUP_2 = 'mg4';
+    const LIVE_COLLECTION = 'I6XLVNjKrBAcBEmqQV0q';
+
+    type AssetMap = Record<string, { assetType: string }>;
+    interface MenuAssetOverrides {
+      menuAssets: AssetMap;
+      menuAssetDisplayOrder?: string[];
+      groupDisplayOrder?: string[];
+    }
+
+    // Pruning is expected in most of these tests; keep its console.warn out of the test output
+    // while still making it assertable (T7/T8).
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    /**
+     * Builds one menu doc with the given asset/display-order shape and structural defaults.
+     * Display-order fields are omitted entirely when not supplied, so a caller can exercise
+     * the legacy "field absent from the doc" shape.
+     */
+    function makePruneMenuDoc(overrides: MenuAssetOverrides) {
+      const data: Record<string, unknown> = {
+        name: 'Prune Menu',
+        displayName: 'Prune',
+        coverImageGsl: null,
+        coverBackgroundImageGsl: null,
+        coverVideoGsl: null,
+        logoImageGsl: null,
+        gratuityRates: [],
+        managedBy: null,
+        isDeleted: false,
+        created: new Date('2024-01-01'),
+        updated: new Date('2024-06-01'),
+        version: '2.0',
+        groups: {},
+        collections: {},
+        menuAssets: overrides.menuAssets,
+      };
+      if (overrides.menuAssetDisplayOrder !== undefined) {
+        data.menuAssetDisplayOrder = overrides.menuAssetDisplayOrder;
+      }
+      if (overrides.groupDisplayOrder !== undefined) {
+        data.groupDisplayOrder = overrides.groupDisplayOrder;
+      }
+      return { id: PRUNE_MENU, data };
+    }
+
+    function registerMenuWithAssets(overrides: MenuAssetOverrides) {
+      registerCollection(MENUS_PATH, [makePruneMenuDoc(overrides)]);
+    }
+
+    function written() {
+      return transactionSets.find((s) => s.ref._docId === PRUNE_MENU)?.data;
+    }
+
+    // T1
+    it('prunes a group-typed asset whose menuGroup doc does not exist from menuAssets, menuAssetDisplayOrder and groupDisplayOrder', async () => {
+      registerMenuWithAssets({
+        menuAssets: {
+          [LIVE_GROUP]: { assetType: 'group' },
+          ghost: { assetType: 'group' },
+          [LIVE_GROUP_2]: { assetType: 'group' },
+        },
+        menuAssetDisplayOrder: [LIVE_GROUP, 'ghost', LIVE_GROUP_2],
+        groupDisplayOrder: ['ghost', LIVE_GROUP, LIVE_GROUP_2],
+      });
+
+      await rebuildMenus(BUSINESS_ID);
+
+      const data = written();
+      expect(Object.keys(data.menuAssets).sort()).toEqual([LIVE_GROUP, LIVE_GROUP_2].sort());
+      expect(data.menuAssetDisplayOrder).toEqual([LIVE_GROUP, LIVE_GROUP_2]);
+      expect(data.groupDisplayOrder).toEqual([LIVE_GROUP, LIVE_GROUP_2]);
+    });
+
+    // T2
+    it('prunes a collection-typed asset whose collection doc does not exist', async () => {
+      registerMenuWithAssets({
+        menuAssets: {
+          [LIVE_GROUP]: { assetType: 'group' },
+          [LIVE_COLLECTION]: { assetType: 'collection' },
+          ghostCol: { assetType: 'collection' },
+        },
+        menuAssetDisplayOrder: [LIVE_GROUP, 'ghostCol', LIVE_COLLECTION],
+        groupDisplayOrder: [LIVE_GROUP],
+      });
+
+      await rebuildMenus(BUSINESS_ID);
+
+      const data = written();
+      expect(Object.keys(data.menuAssets).sort()).toEqual([LIVE_GROUP, LIVE_COLLECTION].sort());
+      expect(data.menuAssetDisplayOrder).toEqual([LIVE_GROUP, LIVE_COLLECTION]);
+      // groupDisplayOrder never contained the collection id, so it is untouched
+      expect(data.groupDisplayOrder).toEqual([LIVE_GROUP]);
+    });
+
+    // T3
+    it('prunes a group whose doc exists but is isDeleted, same as a missing doc', async () => {
+      registerCollection(MENU_GROUPS_PATH, [
+        ...menuGroups,
+        {
+          id: 'deletedGroup',
+          data: {
+            name: 'Deleted Group',
+            displayName: 'Deleted',
+            imageGsls: [],
+            productDisplayOrder: [],
+            mirrorCategoryId: null,
+            isDeleted: true,
+          },
+        },
+      ]);
+      registerMenuWithAssets({
+        menuAssets: {
+          [LIVE_GROUP]: { assetType: 'group' },
+          deletedGroup: { assetType: 'group' },
+        },
+        menuAssetDisplayOrder: [LIVE_GROUP, 'deletedGroup'],
+        groupDisplayOrder: [LIVE_GROUP, 'deletedGroup'],
+      });
+
+      await rebuildMenus(BUSINESS_ID);
+
+      const data = written();
+      expect(Object.keys(data.menuAssets)).toEqual([LIVE_GROUP]);
+      expect(data.menuAssetDisplayOrder).toEqual([LIVE_GROUP]);
+      expect(data.groupDisplayOrder).toEqual([LIVE_GROUP]);
+    });
+
+    // T4
+    it('preserves menuAssets, menuAssetDisplayOrder and groupDisplayOrder verbatim when pruneMenuAssetsOnRebuild is false', async () => {
+      mockGetFlags.mockResolvedValue({ pruneMenuAssetsOnRebuild: false });
+
+      const menuAssets = {
+        [LIVE_GROUP]: { assetType: 'group' },
+        ghost: { assetType: 'group' },
+        [LIVE_GROUP_2]: { assetType: 'group' },
+      };
+      registerMenuWithAssets({
+        menuAssets,
+        menuAssetDisplayOrder: [LIVE_GROUP, 'ghost', LIVE_GROUP_2],
+        groupDisplayOrder: ['ghost', LIVE_GROUP, LIVE_GROUP_2],
+      });
+
+      await rebuildMenus(BUSINESS_ID);
+
+      const data = written();
+      expect(data.menuAssets).toEqual(menuAssets);
+      expect(data.menuAssetDisplayOrder).toEqual([LIVE_GROUP, 'ghost', LIVE_GROUP_2]);
+      expect(data.groupDisplayOrder).toEqual(['ghost', LIVE_GROUP, LIVE_GROUP_2]);
+    });
+
+    // T5 (R1)
+    it('preserves product- and htmlText-typed assets whose ids have no backing group or collection doc', async () => {
+      registerMenuWithAssets({
+        menuAssets: {
+          p_only: { assetType: 'product' },
+          html1: { assetType: 'htmlText' },
+          ghost: { assetType: 'group' },
+        },
+        menuAssetDisplayOrder: ['p_only', 'ghost', 'html1'],
+        groupDisplayOrder: ['ghost'],
+      });
+
+      await rebuildMenus(BUSINESS_ID);
+
+      const data = written();
+      expect(Object.keys(data.menuAssets).sort()).toEqual(['html1', 'p_only']);
+      expect(data.menuAssetDisplayOrder).toEqual(['p_only', 'html1']);
+      expect(data.groupDisplayOrder).toEqual([]);
+    });
+
+    // T6 (R2)
+    it('leaves groupDisplayOrder untouched for legacy menus with an empty menuAssets map', async () => {
+      registerMenuWithAssets({
+        menuAssets: {},
+        menuAssetDisplayOrder: [],
+        groupDisplayOrder: [LIVE_GROUP, LIVE_GROUP_2],
+      });
+
+      await rebuildMenus(BUSINESS_ID);
+
+      const data = written();
+      expect(data.groupDisplayOrder).toEqual([LIVE_GROUP, LIVE_GROUP_2]);
+      expect(data.menuAssets).toEqual({});
+      expect(data.menuAssetDisplayOrder).toEqual([]);
+    });
+
+    // T7
+    it('logs the pruned ids with businessId and menuId', async () => {
+      registerMenuWithAssets({
+        menuAssets: {
+          [LIVE_GROUP]: { assetType: 'group' },
+          ghost: { assetType: 'group' },
+        },
+        menuAssetDisplayOrder: [LIVE_GROUP, 'ghost'],
+        groupDisplayOrder: [LIVE_GROUP, 'ghost'],
+      });
+
+      await rebuildMenus(BUSINESS_ID);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[MenuRebuildService] pruned dangling asset refs',
+        { businessId: BUSINESS_ID, menuId: PRUNE_MENU, prunedIds: ['ghost'] },
+      );
+    });
+
+    // T8
+    it('does not log when nothing was pruned', async () => {
+      await rebuildMenus(BUSINESS_ID);
+
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        '[MenuRebuildService] pruned dangling asset refs',
+        expect.anything(),
+      );
+    });
+
+    // T9
+    it('rebuilds clean fixture menus with menuAssets, menuAssetDisplayOrder and groupDisplayOrder byte-identical to the source docs', async () => {
+      await rebuildMenus(BUSINESS_ID);
+
+      expect(transactionSets).toHaveLength(menus.length);
+      for (const source of menus) {
+        const data = transactionSets.find((s) => s.ref._docId === source.id)?.data;
+        expect(data).toBeDefined();
+        expect(data.menuAssets).toEqual(source.data.menuAssets);
+        expect(data.menuAssetDisplayOrder).toEqual(source.data.menuAssetDisplayOrder);
+        expect(data.groupDisplayOrder).toEqual(source.data.groupDisplayOrder);
+      }
+    });
+
+    // T10
+    it('removes every group and collection asset when none of the backing docs exist', async () => {
+      registerMenuWithAssets({
+        menuAssets: {
+          ghost1: { assetType: 'group' },
+          ghost2: { assetType: 'group' },
+          ghostCol: { assetType: 'collection' },
+        },
+        menuAssetDisplayOrder: ['ghost1', 'ghostCol', 'ghost2'],
+        groupDisplayOrder: ['ghost1', 'ghost2'],
+      });
+
+      await rebuildMenus(BUSINESS_ID);
+
+      const data = written();
+      expect(data.menuAssets).toEqual({});
+      expect(data.menuAssetDisplayOrder).toEqual([]);
+      expect(data.groupDisplayOrder).toEqual([]);
+    });
+
+    // T11
+    it('is a no-op for a menu with empty menuAssets and empty display orders', async () => {
+      registerMenuWithAssets({
+        menuAssets: {},
+        menuAssetDisplayOrder: [],
+        groupDisplayOrder: [],
+      });
+
+      await rebuildMenus(BUSINESS_ID);
+
+      const data = written();
+      expect(data.menuAssets).toEqual({});
+      expect(data.menuAssetDisplayOrder).toEqual([]);
+      expect(data.groupDisplayOrder).toEqual([]);
+    });
+
+    // T12
+    it('handles a menu doc missing menuAssetDisplayOrder and groupDisplayOrder entirely', async () => {
+      registerMenuWithAssets({
+        menuAssets: {
+          [LIVE_GROUP]: { assetType: 'group' },
+          ghost: { assetType: 'group' },
+        },
+      });
+
+      await rebuildMenus(BUSINESS_ID);
+
+      const data = written();
+      expect(Object.keys(data.menuAssets)).toEqual([LIVE_GROUP]);
+      expect(data.menuAssetDisplayOrder).toEqual([]);
+      expect(data.groupDisplayOrder).toEqual([]);
+    });
+
+    // T13
+    it('keeps every group/collection menuAssets key present in the written groups or collections map', async () => {
+      registerCollection(MENUS_PATH, [
+        ...menus,
+        makePruneMenuDoc({
+          menuAssets: {
+            [LIVE_GROUP]: { assetType: 'group' },
+            ghost: { assetType: 'group' },
+            ghostCol: { assetType: 'collection' },
+            [LIVE_COLLECTION]: { assetType: 'collection' },
+          },
+          menuAssetDisplayOrder: [LIVE_GROUP, 'ghost', 'ghostCol', LIVE_COLLECTION],
+          groupDisplayOrder: [LIVE_GROUP, 'ghost'],
+        }),
+      ]);
+
+      await rebuildMenus(BUSINESS_ID);
+
+      expect(transactionSets).toHaveLength(menus.length + 1);
+      for (const set of transactionSets) {
+        const assets: AssetMap = set.data.menuAssets;
+        for (const [id, asset] of Object.entries(assets)) {
+          if (asset.assetType === 'group') {
+            expect(set.data.groups[id]).toBeDefined();
+          } else if (asset.assetType === 'collection') {
+            expect(set.data.collections[id]).toBeDefined();
+          }
+        }
+      }
+    });
+
+    // E3
+    it('propagates a feature-flag read failure instead of pruning or preserving silently', async () => {
+      mockGetFlags.mockRejectedValue(new Error('flag read failed'));
+      registerMenuWithAssets({
+        menuAssets: { [LIVE_GROUP]: { assetType: 'group' } },
+        menuAssetDisplayOrder: [LIVE_GROUP],
+        groupDisplayOrder: [LIVE_GROUP],
+      });
+
+      await expect(rebuildMenus(BUSINESS_ID)).rejects.toThrow('flag read failed');
+      expect(transactionSets).toHaveLength(0);
     });
   });
 
@@ -750,6 +1105,47 @@ describe('MenuRebuildService', () => {
       expect(mockDb.runTransaction).toHaveBeenCalledTimes(2);
       // Only the second attempt should have written
       expect(transactionSets).toHaveLength(1);
+    });
+
+    // #132 / T14
+    it('aborts and retries when menuAssets change between bulk read and transaction while pruning is active', async () => {
+      const bulkData = setupSingleMenu();
+
+      // 'newAsset' is a collection id with no backing collection doc — the retry attempt must
+      // write the FRESH asset set with that dangling id pruned.
+      const freshMenuAssets = {
+        '0YRxtglWpkDyxcW8WCTD': { assetType: 'group' as const },
+        newAsset: { assetType: 'collection' as const },
+      };
+
+      mockDb.runTransaction.mockImplementation(async (fn: (t: any) => Promise<void>) => {
+        mockTransaction.get.mockResolvedValueOnce({
+          id: 'toctou-menu',
+          exists: true,
+          data: () => ({
+            ...bulkData,
+            menuAssets: freshMenuAssets,
+            menuAssetDisplayOrder: ['0YRxtglWpkDyxcW8WCTD', 'newAsset'],
+            groupDisplayOrder: ['0YRxtglWpkDyxcW8WCTD', 'newAsset'],
+          }),
+        });
+        await fn(mockTransaction);
+      });
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      await rebuildMenus(BUSINESS_ID, { menuIds: ['toctou-menu'] });
+
+      warnSpy.mockRestore();
+
+      // First attempt aborts on divergence; second attempt re-reads with the fresh assets.
+      expect(mockDb.runTransaction).toHaveBeenCalledTimes(2);
+      expect(transactionSets).toHaveLength(1);
+
+      const written = transactionSets[0].data;
+      expect(written.menuAssets).toEqual({ '0YRxtglWpkDyxcW8WCTD': { assetType: 'group' } });
+      expect(written.menuAssetDisplayOrder).toEqual(['0YRxtglWpkDyxcW8WCTD']);
+      expect(written.groupDisplayOrder).toEqual(['0YRxtglWpkDyxcW8WCTD']);
     });
 
     it('writes fresh version from transaction, not stale snapshot version', async () => {


### PR DESCRIPTION
Closes #132

Part of **P36: Referential Integrity for Deletes**. Contract: kiosinc/businesses#328 §1b.

## Scope

**In:**
- `rebuildMenus` now prunes dangling `menuAssets` entries — those whose backing menuGroup/collection doc is missing or `isDeleted` — instead of copying them forward forever.
- `menuAssetDisplayOrder` and legacy `groupDisplayOrder` drop the same pruned ids, with surviving ids keeping their relative order.
- New kill switch `pruneMenuAssetsOnRebuild` in `/config/writeModelFlags` (**default `true`**). Flip to `false` to restore verbatim preservation; pruning is loss-free, so rollback needs no data restoration.
- Prune events log `businessId`, `menuId`, and the exact pruned ids (UC13) — only when something was actually pruned.
- The same change is mirrored into the greenfield `libs/kios-firestore` copy (see "Mirror copy" below).

**Out:**
- Pruning `mirrorCategoryId` — square-gateway sweep issue.
- Pruning collections' internal `products`/`menuAssets` maps — square-gateway sweep issue.
- Any repair/backfill of existing prod docs — deferred outside P36; affected menus self-heal on their next rebuild.
- Registering the dormant cascade handlers — deferred to the rcc#58 / businesses#208 family.
- **No `package.json` version bump** — see "Versioning" below.
- **Dangling `product`/`htmlText`-typed asset ids are not fixed** — see R1 below.

## Summary

`attemptRebuild` materialized `groups`/`collections` from surviving docs but wrote `menuAssets`, `menuAssetDisplayOrder`, and `groupDisplayOrder` back verbatim. Half the doc was derived, half was carried forward — and the carried-forward half is the *index* into the derived half. So a hard-deleted menuGroup left a permanently dangling asset id that every rebuild re-created, and `extractAssetIdsByType` re-fed the dead id to `batchGetDocs` forever.

The fix derives the index from the same source the body was derived from: the survivor set is the key set of `materializedGroups` / `materializedCollections`, which by construction contains exactly the ids whose doc existed and was not `isDeleted`. This satisfies both of the contract's prune conditions with no second predicate to keep in sync, and establishes a new invariant on the written doc:

> every `group`/`collection`-typed key of `menuAssets` is present in `groups` ∪ `collections`.

**Contract compliance:** pruning is computed **inside** the write transaction from the fresh in-transaction read (`existingData`), exactly as §1b requires. The `menuAssetsEqual` TOCTOU guard (#50) is untouched — a concurrent `menuAssets` change still aborts the write and retries. Only the *flag lookup* moved outside `runTransaction`, because transaction callbacks are retried and a non-transactional read inside one is an anti-pattern (the snippet in the issue body had it inside; that was corrected).

### Two documented refinements to the issue's suggested patch

**R1 — pruning is `assetType`-aware.** `MenuAsset.assetType` is `'product' | 'group' | 'collection' | 'htmlText'`, but `attemptRebuild` only batch-reads `group` and `collection` ids. The issue's suggested snippet filtered *all* entries against a survivor set built solely from menuGroups/collections, which would have silently deleted every `product`- and `htmlText`-typed asset — data loss, and contrary to the contract's own "pruning is loss-free" invariant. Only `group`/`collection` entries are pruning candidates here; `product`/`htmlText` are always preserved.

*Residual:* a dangling `product`-typed asset id therefore stays dangling. Closing that needs a third `batchGetDocs` against `products` keyed by asset id — a new read, out of scope for this issue, worth a follow-up.

**R2 — `groupDisplayOrder` drops only what was actually pruned.** The contract's literal wording ("drop ids not present in the pruned `menuAssets`") would wipe `groupDisplayOrder` wholesale for any legacy menu whose `menuAssets` is `{}` (`createMenu` defaults it to `{}`). An id is dropped iff it was present in `menuAssets` and did not survive; ids never in `menuAssets` are left untouched. For modern menus — where `groupDisplayOrder ⊆ group-typed menuAssets ids`, true for all four fixture menus — this is byte-identical to the literal rule. It only differs by being non-destructive in the legacy shape.

### Other decisions worth a reviewer's attention

- **No fail-open on the flag read.** `getFlags()` rejecting propagates rather than defaulting to `true` — swallowing it would suppress a real infrastructure failure and make the kill switch un-flippable during a Firestore incident. Pinned by a test.
- **Cost.** `businesses` has no upstream `getFlags()` gate on this path, so this adds one `config/writeModelFlags` doc read per process per 60s TTL window. `square-gateway-claude`'s `importCatalog` already calls `getFlags()` on the same path, so its cache is warm.
- **`prunedIds` is reset per transaction attempt** so the post-commit log can never report a prune from an attempt that was rolled back.
- **Consumer audit:** `WriteModelFlags` is public (`Domain.Services.WriteModelFlags`), so adding a required field is a contract change. Swept every consumer across the monorepo — square-gateway, businesses, cloud-functions, django. **Additive-safe: no consumer constructs a `WriteModelFlags` object literal** (the only literals are each package's own `DEFAULT_FLAGS`, both updated here; django has a wholly independent all-optional interface reading the same Firestore doc). No migration, no consumer PRs. `MaterializedMenuDoc` is module-local and not exported.

## Mirror copy (`libs/kios-firestore`) — not in this diff

Per the issue's requirement 4, the equivalent change was applied to the greenfield copy at `KIOS/libs/kios-firestore/src/application/` (`MenuRebuildService.ts`, `FeatureFlagService.ts`, and both test files). **That workspace is not a git repository, so those changes cannot appear in this PR's diff.** Verified there independently: `npx tsc --noEmit` clean, `npm test` 280 passing across 37 files (up from 272 — 8 new behavioural tests, replacing a suite that previously had only a fixture-count stub).

That copy is materially older — no `attemptRebuild`, no `menuAssetsEqual`, no TOCTOU guard, no retry loop — so it is a **minimal mirror**: it prunes the values it actually writes, and fresh-read/TOCTOU semantics were deliberately not back-ported. Consequently **test-strategy case 5 (TOCTOU) has no analogue there** and none was invented. Its `MenuAsset.assetType` union also has no `htmlText` member.

## Versioning

**No `package.json` bump in this PR, deliberately.** The base branch `project/36` already carries an unpublished `1.17.0` (bumped by the earlier #141/#142 work on this same integration branch) while `dev`/`master` are still at `1.16.0`, and a sibling issue is in flight off the same base — a second bump would be a pure textual conflict for zero benefit. The `project/36` → `dev` rollup merge publishes `1.17.0-dev.<sha>`, which discharges the issue's "version published" and "version noted on the P36 tracking issue" acceptance criteria via the orchestrator's `library_publish_bridge` step, not via this PR.

## Test plan

- [x] Automated tests pass — **746 passing across 79 files** (baseline 729). `MenuRebuildService.test.ts` 58 (43 pre-existing, all unchanged and green, + 15 new); `FeatureFlagService.test.ts` 11 (9 + 2).
- [x] All 5 existing TOCTOU tests pass unchanged, with pruning active.
- [x] `npx tsc --noEmit` clean.
- [x] `npx eslint src/` — no new errors or warnings (baseline on this tree is 16 errors / 438 warnings on untouched files; verified byte-identical via stash).
- [x] The pre-existing `skips deleted groups` test — which silently reproduced this bug — was strengthened with the three assertions that fail before the fix and pass after.

New coverage: group-missing, collection-missing, `isDeleted`-group, flag-off verbatim preservation, `product`/`htmlText` preserved (R1), legacy empty-`menuAssets` (R2), prune log contains the ids, no log when nothing pruned, clean-fixture byte-identical rebuild, all-pruned / empty / missing-display-order boundaries, the new invariant, flag-read failure propagates, and TOCTOU-abort-with-pruning-active.

Manual verification (post-merge, after the publish bridge):
- [ ] Confirm the prod dangling ref (`k11t67BGQXy6SQ5BvtUr` / menu `yE6aZMoi8doY4iTfN22x` / id `HqKBbsHomrJWeZgHdURY`) and **record its `assetType`** — if it is not `group`/`collection`, R1 means this PR does not fix that specific case.
- [ ] Dev end-to-end: rebuild a menu seeded with a dangling group ref → pruned from all three fields, survivor order intact.
- [ ] Cloud Logging shows `[MenuRebuildService] pruned dangling asset refs` with the id array; a clean-menu rebuild emits nothing.
- [ ] Kill-switch round trip: `false` → preserved, `true` → pruned (respecting the 60s TTL).
- [ ] Remy + django smoke on the pruned dev menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
